### PR TITLE
【开源实习】香橙派github仓中的在线推理案例01-quick start基于PyNative模式改写成以mint接口实现

### DIFF
--- a/Online/inference/01-quick start/mindspore_quick_start.ipynb
+++ b/Online/inference/01-quick start/mindspore_quick_start.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "| 香橙派AIpro | 镜像 | CANN Toolkit/Kernels | MindSpore |\n",
     "| :----:| :----: | :----:| :----: |\n",
-    "| 8T 16G | Ubuntu | 8.0.0beta1| 2.5.0 |\n",
+    "| 8T 8G | Ubuntu | 8.1.RC1 | 2.6.0 |\n",
     "\n",
     "### 镜像烧录\n",
     "\n",
@@ -40,14 +40,14 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/miniconda3/lib/python3.9/site-packages/numpy/core/getlimits.py:499: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
+      "/usr/local/miniconda3/lib/python3.9/site-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
       "  setattr(self, word, getattr(machar, word).flat[0])\n",
       "/usr/local/miniconda3/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
       "  return self._float_to_str(self.smallest_subnormal)\n",
-      "/usr/local/miniconda3/lib/python3.9/site-packages/numpy/core/getlimits.py:499: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
+      "/usr/local/miniconda3/lib/python3.9/site-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
       "  setattr(self, word, getattr(machar, word).flat[0])\n",
       "/usr/local/miniconda3/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
       "  return self._float_to_str(self.smallest_subnormal)\n"
@@ -59,8 +59,19 @@
     "from mindspore import mint\n",
     "from mindspore.nn import Cell, SGD\n",
     "from mindspore.mint import nn\n",
+    "from mindspore.mint.nn import functional as F\n",
     "from mindspore.dataset import vision, transforms\n",
     "from mindspore.dataset import MnistDataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mindspore.set_context(mode=mindspore.PYNATIVE_MODE)\n",
+    "mindspore.set_device(\"Ascend\")"
    ]
   },
   {
@@ -74,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "tags": []
    },
@@ -83,15 +94,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Defaulting to user installation because normal site-packages is not writeable\n",
-      "Requirement already satisfied: download in /home/HwHiAiUser/.local/lib/python3.9/site-packages (0.3.5)\n",
-      "Requirement already satisfied: tqdm in /home/HwHiAiUser/.local/lib/python3.9/site-packages (from download) (4.66.5)\n",
+      "Requirement already satisfied: download in /usr/local/miniconda3/lib/python3.9/site-packages (0.3.5)\n",
       "Requirement already satisfied: six in /usr/local/miniconda3/lib/python3.9/site-packages (from download) (1.16.0)\n",
-      "Requirement already satisfied: requests in /home/HwHiAiUser/.local/lib/python3.9/site-packages (from download) (2.32.2)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in /home/HwHiAiUser/.local/lib/python3.9/site-packages (from requests->download) (2.2.3)\n",
+      "Requirement already satisfied: tqdm in /usr/local/miniconda3/lib/python3.9/site-packages (from download) (4.64.1)\n",
+      "Requirement already satisfied: requests in /usr/local/miniconda3/lib/python3.9/site-packages (from download) (2.31.0)\n",
       "Requirement already satisfied: idna<4,>=2.5 in /usr/local/miniconda3/lib/python3.9/site-packages (from requests->download) (3.4)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/miniconda3/lib/python3.9/site-packages (from requests->download) (2.0.4)\n",
       "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/miniconda3/lib/python3.9/site-packages (from requests->download) (2023.11.17)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/miniconda3/lib/python3.9/site-packages (from requests->download) (2.0.4)\n"
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/miniconda3/lib/python3.9/site-packages (from requests->download) (1.26.14)\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\u001b[33m\n",
+      "\u001b[0m"
      ]
     }
    ],
@@ -103,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -112,7 +124,7 @@
      "text": [
       "Downloading data from https://mindspore-website.obs.cn-north-4.myhuaweicloud.com/notebook/datasets/MNIST_Data.zip (10.3 MB)\n",
       "\n",
-      "file_sizes: 100%|██████████████████████████| 10.8M/10.8M [00:02<00:00, 4.50MB/s]\n",
+      "file_sizes: 100%|██████████████████████████| 10.8M/10.8M [00:00<00:00, 11.7MB/s]\n",
       "Extracting zip file...\n",
       "Successfully downloaded / unzipped to ./\n"
      ]
@@ -149,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -190,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -250,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -278,19 +290,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Network<\n",
-      "  (dense1): Linear<input_features=784, output_features=512, has_bias=True>\n",
-      "  (dense2): Linear<input_features=512, output_features=512, has_bias=True>\n",
-      "  (dense3): Linear<input_features=512, output_features=10, has_bias=True>\n",
-      "  (relu): ReLU<>\n",
-      "  >\n"
+      "Network(\n",
+      "  (dense1): Linear(input_features=784, output_features=512, has_bias=True)\n",
+      "  (dense2): Linear(input_features=512, output_features=512, has_bias=True)\n",
+      "  (dense3): Linear(input_features=512, output_features=10, has_bias=True)\n",
+      "  (relu): ReLU()\n",
+      ")\n"
      ]
     }
    ],
@@ -308,9 +320,9 @@
     "    def construct(self, x):\n",
     "        x = self.flatten(x, start_dim=1)\n",
     "        x = self.dense1(x)\n",
-    "        x = self.relu(x)\n",
+    "        x = F.relu(x)\n",
     "        x = self.dense2(x)\n",
-    "        x = self.relu(x)\n",
+    "        x = F.relu(x)\n",
     "        logits = self.dense3(x)\n",
     "        return logits\n",
     "\n",
@@ -349,7 +361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -392,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -404,7 +416,7 @@
     "        pred = model(data)\n",
     "        total += len(data)\n",
     "        test_loss += loss_fn(pred, label).asnumpy()\n",
-    "        correct += (pred.argmax(1) == label).asnumpy().sum()\n",
+    "        correct += (mint.argmax(pred, dim=1) == label).asnumpy().sum()\n",
     "    test_loss /= num_batches\n",
     "    correct /= total\n",
     "    print(f\"Test: \\n Accuracy: {(100*correct):>0.1f}%, Avg loss: {test_loss:>8f} \\n\")"
@@ -419,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -428,48 +440,62 @@
      "text": [
       "Epoch 1\n",
       "-------------------------------\n",
-      "loss: 2.298828  [  0/938]\n",
-      "loss: 1.756836  [100/938]\n",
-      "loss: 0.783691  [200/938]\n",
-      "loss: 0.732910  [300/938]\n",
-      "loss: 0.426514  [400/938]\n",
-      "loss: 0.547363  [500/938]\n",
-      "loss: 0.283203  [600/938]\n",
-      "loss: 0.833496  [700/938]\n",
-      "loss: 0.241455  [800/938]\n",
-      "loss: 0.342773  [900/938]\n",
-      ".Test: \n",
-      " Accuracy: 90.7%, Avg loss: 0.321171 \n",
+      ".loss: 2.304688  [  0/938]\n",
+      "loss: 1.767578  [100/938]\n",
+      "loss: 0.999512  [200/938]\n",
+      "loss: 0.636230  [300/938]\n",
+      "loss: 0.547363  [400/938]\n",
+      "loss: 0.375977  [500/938]\n",
+      "loss: 0.731934  [600/938]\n",
+      "loss: 0.288574  [700/938]\n",
+      "loss: 0.363770  [800/938]\n",
+      "loss: 0.261230  [900/938]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[WARNING] MD(3780,e7ff1e74f120,python):2025-07-12-14:06:09.147.883 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:146] operator()] Memory consumption is more than 80.6116%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n",
+      "[WARNING] MD(3780,e7ff2078f120,python):2025-07-12-14:06:12.756.141 [mindspore/ccsrc/minddata/dataset/engine/datasetops/batch_op.cc:146] operator()] Memory consumption is more than 80.3526%, which may cause OOM. Please reduce num_parallel_workers size / optimize 'per_batch_map' function / other python data preprocess function to reduce memory usage.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test: \n",
+      " Accuracy: 90.8%, Avg loss: 0.324486 \n",
       "\n",
       "Epoch 2\n",
       "-------------------------------\n",
-      "loss: 0.275879  [  0/938]\n",
-      "loss: 0.311035  [100/938]\n",
-      "loss: 0.294189  [200/938]\n",
-      "loss: 0.458740  [300/938]\n",
-      "loss: 0.292725  [400/938]\n",
-      "loss: 0.177612  [500/938]\n",
-      "loss: 0.367920  [600/938]\n",
-      "loss: 0.219482  [700/938]\n",
-      "loss: 0.226685  [800/938]\n",
-      "loss: 0.230103  [900/938]\n",
+      "loss: 0.236450  [  0/938]\n",
+      "loss: 0.406738  [100/938]\n",
+      "loss: 0.252686  [200/938]\n",
+      "loss: 0.475830  [300/938]\n",
+      "loss: 0.288330  [400/938]\n",
+      "loss: 0.273682  [500/938]\n",
+      "loss: 0.277344  [600/938]\n",
+      "loss: 0.244873  [700/938]\n",
+      "loss: 0.302246  [800/938]\n",
+      "loss: 0.394531  [900/938]\n",
       "Test: \n",
-      " Accuracy: 92.8%, Avg loss: 0.253441 \n",
+      " Accuracy: 92.7%, Avg loss: 0.254096 \n",
       "\n",
       "Epoch 3\n",
       "-------------------------------\n",
-      "loss: 0.310791  [  0/938]\n",
-      "loss: 0.213379  [100/938]\n",
-      "loss: 0.247925  [200/938]\n",
-      "loss: 0.227783  [300/938]\n",
-      "loss: 0.518066  [400/938]\n",
-      "loss: 0.197266  [500/938]\n",
-      "loss: 0.199219  [600/938]\n",
-      "loss: 0.143188  [700/938]\n",
-      "loss: 0.383545  [800/938]\n",
-      "loss: 0.290283  [900/938]\n",
+      "loss: 0.212646  [  0/938]\n",
+      "loss: 0.347168  [100/938]\n",
+      "loss: 0.284424  [200/938]\n",
+      "loss: 0.133423  [300/938]\n",
+      "loss: 0.239502  [400/938]\n",
+      "loss: 0.427490  [500/938]\n",
+      "loss: 0.189453  [600/938]\n",
+      "loss: 0.193604  [700/938]\n",
+      "loss: 0.324219  [800/938]\n",
+      "loss: 0.370605  [900/938]\n",
       "Test: \n",
-      " Accuracy: 93.8%, Avg loss: 0.215057 \n",
+      " Accuracy: 93.7%, Avg loss: 0.214151 \n",
       "\n",
       "Done!\n"
      ]
@@ -495,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -531,7 +557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -569,19 +595,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Predicted: \"[6 9 4 8 9 3]\", Actual: \"[6 9 4 8 9 3]\"\n"
+      "Predicted: \"[5 8 5 9 9 3]\", Actual: \"[5 8 5 9 9 3]\"\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgMAAAGFCAYAAABg2vAPAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8g+/7EAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAofklEQVR4nO3de3DU1d3H8W8CBEhACCEElBAoN9FyGWJVEEEUFBAKVC4i1ajYh8dHERQUxUorIjCWItYL6MB4QfpwUdCOghYoiFJEBYql1gd0QCgoBuUmcjFwnj/OZEL4niW/ze5md3Perxlm9ZPf5bA5Wb45e87ZFGOMEQAA4K3UeDcAAADEF8UAAACeoxgAAMBzFAMAAHiOYgAAAM9RDAAA4DmKAQAAPEcxAACA5ygGAADwHMWAQ9OmIrfeWvL/a9aIpKTYx0RxdhsBEfoukhd9N74Sshh46SXbCYr/1Kgh0qqVyN13i+zbF+/WBbdsmcjvfx/vVlgrV4pcfbVInToitWuL5OeLLFwY71ZVPvTd6FqxQqRLF5H0dJHMTJFBg0R27ox3qyon+m7s/OY39jnt2zfeLQmtarwbcC6TJok0ayZy/LjIBx+IzJplv9Fbt9oXh4rStavIsWMiaWnhnbdsmcizz8a/Y774osiIESI9e4pMmSJSpYrI//2fyO7d8W1XZUbfjdxbb4n07y/SsaPItGkihw+LPPWULQ42bxbJzo5f2yoz+m50ffKJLbRq1Ih3S84toYuB3r1FLrnE/vcdd4hkZYnMmCHy5psiw4bp448eFcnIiH47UlMT/xsZys6dInfdJTJqlH0hRcWg70Zu/HiRn/1MZN26kn8Q+vUrKQ7++Mf4tq+you9GjzEi99wjcsstIqtWxbs155aQbxOEcvXV9nHHDvu+Ta1aIl9+KdKnjx36Hj7cfv30aZGZM0Uuvth2ppwckZEjRQ4cKH09Y0QmTxZp3NhWvN27i/zrX/q+od672rDB3jsz0/4wtGtX8g/urbfa6lSk9NBbsWi3UcQ+F19+WTqbPVvk1Clb7YuI/PCDvSYqFn03vL77/fcin30mMnBg6d8M27cXadNGZMEC93UQffTd8F93i82bZ0dUHn/c/fVEktAjA2crfsKzsuxjUZHIddfZYcPp00uGsEaOtMMyt91mq7IdO0SeecYOLa5bJ1Ktmj1u4kT7De/Tx/7ZtEnk2mtFTp4suy0rVtj3fxo1Ehk9WqRhQ5F//9sObY4ebduwd689bt48fX4s2njNNfbxzPdUV64UufBCO3R2//0ie/bYH6K77hJ59FFbfSP26Lvh9d0TJ+xjzZr62PR0+8L8zTe27Ygt+m74r7siIkeO2NGtCROSpJ+aBPTii8aIGLNypTGFhcbs3m3MggXGZGUZU7OmMf/5jzEFBfaYBx8sfe7779t8/vzS+TvvlM6//daYtDRjrr/emNOnS46bMMEeV1BQkq1ebbPVq+3/FxUZ06yZMXl5xhw4UPo+Z17rrrvseWeLRRuNse3JyyudnXeeMZmZxlSvbswjjxjz2mvG3HST+7lD5Oi74bfRGN13T50ypm5dY665pvRx+/cbk5Fhr/HJJ7p9KD/6bvhtNMb9umuMMePG2fYeP15y3PXX6+MSRUL/Xtijh50klJsrcuONdnhq6VKRCy4oOebOO0ufs3ixnTHfs6fI/v0lf/Lz7fmrV9vjVq60Vd6oUaWHkcaMKbtdmzfbinLMGJG6dUt/7cxrhRKrNu7cqavTH36wQ2CPPmrfKrjhBpH580V69bJDa0eOlN1ehI++G1nfTU21v8WtWiXy0EMi27eLbNwoMmRIyW9nx46V3V6Ej74b+evutm329fUPfxCpXr3stiWChH6b4Nln7dKWqlXtezutW5ce1q5a1b6nc6bt20UOHRJp0MB9zW+/tY9ffWUfW7Ys/fXsbDuMfi7Fw2Y//3mwv8fZKqKNxWrWtBN8zp74M2yYyDvv2B+wrl2Dtx3B0HfL38ZikybZF+snnrATBkXsUO2IEXYuTK1a4bcfZaPvlr+NxUaPFunc2f7ylSwSuhi49NKSWa0u1avr97xPn7bf7Pnz3eckwnKkimzj+efbH4KcnNJ58Q/E2RNnEB303cilpYnMmWMnX23bZvtwq1YiN91kn7sWLaJ3L5Sg70bmb3+zv2gtWVJ6xKCoyI5m7dwpUq+eyHnnRed+0ZLQxUB5NG9uh3muuMI9+ahYXp593L7dLl8qVlhY9j+QzZvbx61b7ZBaKKGGriqijcXy8+35e/aUvsbevfYxEX5IYdF33XJySorZU6fs7PLLLmNkIJHQd0vs2mUff/Ur/bU9e+weDk8+GeytkYqU0HMGymPIEPuC8dhj+mtFRSIHD9r/7tHDzhx9+unSS+1mziz7Hh072m/ozJkl1yt25rWK196efUys2uha4jJ0qH2cO7ckO33abkRUr54tFpAY6Ltlt3/6dJGvvxYZO7bsY1Fx6Lsl/3/11XaOxdl/srPtiMvSpXa/jERT6UYGunWzE4+mThX5xz/se4zVqtkqb/FiO6lj0CD7jRk3zh7Xt69dPrJ5s8jy5SL165/7Hqmpdleufv1EOnSwy1QaNRL5/HO75Ondd+1xxf/Q3nOPXYpTpYqdkBOrNrqWuPTvb/OpU+37r+3bi7zxht1Z7Pnnk2dyiw/ou6X77quvirz+up3TUquW/a1u0SK7EU4yvRfrA/puSd9t0sT+OduYMXaEa8CAcJ/dChLv5QwuxUtcPv449DEFBXaJUSgvvGBMfr5dElO7tjFt2xrzwAPG7N1bcsypU8Y8+qgxjRrZ4666ypitW+0SkHMtcSn2wQfG9Oxpr5+RYUy7dsY8/XTJ14uKjBk1ypjsbGNSUvRyl2i20ZjQS1yOHDFm9GhjGja0S2batjXm1VdDP3coP/pu+G00xt13N2wwpmtXuzS2Rg1j2rc3Zvbs0su9ED303fDbaEzo192zJfrSwhRj2I8OAACfVbo5AwAAIDwUAwAAeI5iAAAAz1EMAADgOYoBAAA8RzEAAIDnKAYAAPBc4B0IU4J8RiRQhnhsa0HfRTTQd5GsgvRdRgYAAPAcxQAAAJ6jGAAAwHMUAwAAeI5iAAAAz1EMAADgOYoBAAA8RzEAAIDnKAYAAPAcxQAAAJ6jGAAAwHMUAwAAeI5iAAAAz1EMAADgucAfYYzS8vPzVbZs2TKVZWdnq6ywsNB5zZycnMgbBgBAmBgZAADAcxQDAAB4jmIAAADPUQwAAOA5JhCWk2uyYFZWlspckwV79+4dkzYBAFAejAwAAOA5igEAADxHMQAAgOcoBgAA8BwTCM+QkZHhzF955RWVuXYWNMaorFu3bir7/PPPy9E6AABig5EBAAA8RzEAAIDnKAYAAPAcxQAAAJ5jAuEZLrzwQmfev39/lbkmCz7++OMqY7IgKkKHDh0C57fffrvKrrzySpVNmTJFZdu3b3fe55tvvlHZO++84zwWOFNeXp4zLyoqUtmePXti3RwREenevbvK3nrrLZXdd999Knv++edj0qZYY2QAAADPUQwAAOA5igEAADxHMQAAgOdSjGsmnOvAlJRYt6VCuXYQfO+995zHtm7dWmW7d+9W2SWXXKKy/fv3l6N1lVfA7hZVydJ369evr7JevXqpzDUBMNQkrCZNmgS6d2qq/r3g9OnTgc4VETl06JDKPv30U5UNGTJEZcnyM0LfjVx+fr7KQk00PXbsmMqC9udIuT6i3vWzuGrVKpX17NkzJm2KRJC+y8gAAACeoxgAAMBzFAMAAHiOYgAAAM9RDAAA4DlvtyMeOHCgylyrBkTcMzFdW04my6xoJKYnnnhCZQUFBSoLZ5Z/RalTp47KXFsc//Wvf1XZr371K5Xt3LkzKu1CxcjKylLZ8OHDVfa73/1OZZmZmc5rurYjdvUz10qWcDRt2lRlobamr8wYGQAAwHMUAwAAeI5iAAAAz1EMAADgOW8nELomN4Wz9efUqVOj2Rx45PLLL3fmOTk55b5mqAl3Q4cOVdl3331X7vv079/fmd9yyy0qa9++faBs4cKFKrvsssvK0TrEy8yZM1XmmkAYDtfrcUZGhsoinUDomrjrmlR48uRJlc2ePTuieycSRgYAAPAcxQAAAJ6jGAAAwHMUAwAAeC7FBPyQ7mT+XO3s7GyVffTRRyoL9VnZS5YsUdngwYMjb5iHfPtM+AEDBqjspZdech7rmhyVmqrr9SlTpqjstddec15zy5Yt525glFx11VUqW7Fihcpcf58jR46ozLXzoojIm2++GX7josS3vlu1qp5fvnTpUuexffr0UZmr7a7ncNOmTc5rDhs2TGVffPGF89gg0tPTnfnXX3+tstq1a6vs7bffVlm/fv3K3Z6KFKTvMjIAAIDnKAYAAPAcxQAAAJ6jGAAAwHNe7ED42GOPqcw1WTDUZB12G0R5dejQQWWuyUkiIh988IHK5s2bp7I5c+ZE3K5oW7NmjcqqVaumMtdEJtfz4dqpUCS+Ewh985e//EVlvXr1Cny+6/X0n//8p8p+8YtfhNewcgq1e2aon8ezhZroWFkwMgAAgOcoBgAA8BzFAAAAnqMYAADAcxQDAAB4zovVBC7x2FoUlZtr+9bzzjtPZadPn3aeP3fuXJW98sorkTesAjRu3FhlrudjxowZKnPN8j548GBU2oVg0tLSVObaYjocu3btUtnw4cMjumZQ9evXV9mDDz4Y0TV/+umniM5PdIwMAADgOYoBAAA8RzEAAIDnKAYAAPCctxMIXVtlhtpusrJvQ4noqFWrlsratWsXh5ZER926dVU2evRo57GjRo1SWZ06dVTm2l65RYsW4TcOUTVs2DCV1ahRI6Jr5ubmqmzjxo0qW7JkifP8BQsWqCzodtQNGjRQWdu2bQOdKyLy3XffqWzWrFmBz09GjAwAAOA5igEAADxHMQAAgOcoBgAA8Jy3EwhdOxC6dq0Kle/fvz/qbUJyc+2a9/7776usW7duzvNbt24d7SY5XXjhhSpr2LChyiZMmKCy7t27x6RNiK9Qu2JGW7Vq1VQ2dOhQ57Gu/PPPPw90H9eOiuGYPXu2ylyTCisTRgYAAPAcxQAAAJ6jGAAAwHMUAwAAeM7bCYSuHQjz8vKcx+bn56vs3XffVVl2dnagcwcMGOC8j+t810THO++8U2WFhYXOayJ5PPDAAyo7//zzVTZnzhyVjRgxIvB9rrjiCpW5dgGsqElliD/XzpCpqfp3xVCvXRdccIHKXDtQtmzZMvzGncE1+TUWXK+nrkmJJ0+erIjmVAhGBgAA8BzFAAAAnqMYAADAcxQDAAB4LsW4Zqi5DnRMuEsWY8aMUdn06dNVFurv+MILL6hs4sSJKlu2bJnKOnbsqLJQT7nr/q5jN2/erLLevXurLBF3SQzY3aIq0frujh07nHmTJk1U5prEFYuJfRV1nypVqkT9mhWFvhueoBMIe/To4Tx//Pjxga5ZUT799FOVuX6WQ33M8ksvvRTtJgUWpO8yMgAAgOcoBgAA8BzFAAAAnqMYAADAcxQDAAB4zovVBK4tLD/++GOVZWRkOM93PUVBZ/7/+OOPKgv1mdyu+7s+4951b9dqAteWyfHGjGyRgoICZ/7UU0+prHbt2iqLxSx/Vz89cOCAylzbzobiWs3SqFGj8BqWQOi7FatqVb1bvuv5WL9+vcpcq7gqytGjR52562e5orCaAAAAlIliAAAAz1EMAADgOYoBAAA8p2doVEKuCXtLly5V2fDhw53nB504tGTJEpU98sgjgdojIpKenq6yDRs2qOyiiy5SmetzxhNxAiFEXn75ZWd+8OBBlbVv315lt9xyi8ry8vKc13RNSjx8+LDKtmzZEijbvn278z4uru1kgaCKiooCHRfpxE7XNsGu7Oabb1aZa9K3a7v4ZMDIAAAAnqMYAADAcxQDAAB4jmIAAADPebEDoYtrV8K1a9c6j83KylKZ6/PfJ0+erLI//elPKissLHTexzUJ7KOPPlJZgwYNVJafn6+yTZs2Oe8TT+ziFrmcnByV1ahRw3nsnj17VOaamNWwYUOVvfLKKyrr3r278z4ffvihyly7Yv7www/O85MBfTcxuXaTdb0ehpKZmamyQ4cORdSmRMMOhAAAoEwUAwAAeI5iAAAAz1EMAADgOS92IHRx7QI4ZcoU57HTp09XmetjZB966CGV/frXv1aZ66NdRdw7ELomL8biI2yRPPbt2xf1ay5atEhlnTp1Cnz+iRMnVJbMkwWRmK699lqVtWzZMg4tqXwYGQAAwHMUAwAAeI5iAAAAz1EMAADgOW8nELrMnz/fmTdp0kRlvXr1Ulnr1q1V1rRp00DXE3HvauiaLDhx4kSVJeJug0hMXbp0UdmVV16psnAmqo4YMSKiNgFBDBkyRGXnnXdeoHO/+OILZ37y5MmI2lRZMDIAAIDnKAYAAPAcxQAAAJ6jGAAAwHMUAwAAeI7VBGcoLCx05vfdd5/Kfvvb36ps4MCBKpswYYLKXKsOREQmT56ssqVLl6qMlQOIxO23364y18oB1yzrZ5991nnNWGyRDERT7dq1nblrFZePeBYAAPAcxQAAAJ6jGAAAwHMUAwAAeC7FGGMCHZiSEuu2wAMBu1tU+dx3Xdthv/766yrr0KGDynbs2KGyFi1aRKNZSYm+W7GqVaumsv3796ss1MTAs82bN8+ZFxQUhNewJBSk7zIyAACA5ygGAADwHMUAAACeoxgAAMBz7EAIVGKTJk1SWbt27eLQEiA8rsmTQScL7tmzR2UPPPBAxG2qzBgZAADAcxQDAAB4jmIAAADPUQwAAOA5JhAClZhr0lReXp7KunTporK5c+fGpE1AED/99JPK7r33XpU9/PDDKlu/fr3K+Jjtc2NkAAAAz1EMAADgOYoBAAA8RzEAAIDnKAYAAPBcign4Id0+f642oofPhEeyou8iWQXpu4wMAADgOYoBAAA8RzEAAIDnKAYAAPAcxQAAAJ6jGAAAwHMUAwAAeI5iAAAAz1EMAADgucA7EAIAgMqJkQEAADxHMQAAgOcoBgAA8BzFAAAAnqMYAADAcxQDAAB4jmIAAADPUQwAAOA5igEAADxHMQAAgOcoBgAA8BzFAAAAnqMYAADAcxQDAAB4jmIAAADPUQwAAOA5igEAADxHMQAAgOcoBgAA8BzFAAAAnqMYAADAcxQDAAB4jmIAAADPUQwAAOA5igEAADxHMQAAgOcoBgAA8BzFAAAAnqMYAADAcxQDAAB4jmIAAADPUQwAAOA5igEAADxHMQAAgOcoBhyaNhW59daS/1+zRiQlxT4mirPbCIjQd5G86LvxlZDFwEsv2U5Q/KdGDZFWrUTuvltk3754ty64ZctEfv/7eLdCZONGkb59RRo2FKlVS6RdO5E//Unk1Kl4t6zyoe9G14oVIl26iKSni2RmigwaJLJzZ7xbVTnRd6Nn7VqRX/5SJDfXPo8NG4r06iWybl1823UuVePdgHOZNEmkWTOR48dFPvhAZNYs+43eutW+OFSUrl1Fjh0TSUsL77xly0SefTa+HXPjRpHOnUVathQZP94+b8uXi4weLfLllyJPPRW/tlVm9N3IvfWWSP/+Ih07ikybJnL4sO2vXbqIbN4skp0dv7ZVZvTdyG3bJpKaKvLf/20LgQMHRF591f6d3n7bFgaJJqGLgd69RS65xP73HXeIZGWJzJgh8uabIsOG6eOPHhXJyIh+O1JTbXWXjJ5/3j6uXStSr57975EjRbp1s78JUAzEBn03cuPHi/zsZ/a3qeJ/EPr1KykO/vjH+LavsqLvRu6OO+yfM/3P/9j+PHNmYhYDCfk2QShXX20fd+yw79vUqmV/u+3TR6R2bZHhw+3XT5+2T/jFF9vOlJNj/wE8cKD09YwRmTxZpHFjW/F27y7yr3/p+4Z672rDBnvvzEz7w9CuXck/rrfeaqtTkdJDb8Wi3UYR+1x8+WXp7PBhe/26dUvnjRqJ1Kzpvg6ij74bXt/9/nuRzz4TGTiw9G+G7duLtGkjsmCB+zqIPvpu+K+7LunpdjTr4MGyj42HhB4ZOFvxE56VZR+LikSuu84OG06fXjKENXKk/a33tttE7rnHduJnnrFDi+vWiVSrZo+bONF+w/v0sX82bRK59lqRkyfLbsuKFfZ9+EaN7JB7w4Yi//63HdocPdq2Ye9ee9y8efr8WLTxmmvs45nvqV51lcjChfZ+991X8jbBkiUif/hD2X9PRAd9N7y+e+KEfXQVrOnp9oX5m29s2xFb9N3wX3eLHT5sz9m/X+SVV+xbLRMmlP33jAuTgF580RgRY1auNKaw0Jjdu41ZsMCYrCxjatY05j//MaagwB7z4IOlz33/fZvPn186f+ed0vm33xqTlmbM9dcbc/p0yXETJtjjCgpKstWrbbZ6tf3/oiJjmjUzJi/PmAMHSt/nzGvddZc972yxaKMxtj15eaWzoiJj7r7bmGrV7DkixlSpYsysWbpdiBx9N/w2GqP77qlTxtSta8w115Q+bv9+YzIy7DU++US3D+VH3w2/jca4X3eLXXddyetuWpoxI0cac+yY+9h4S+i3CXr0sMMqubkiN95oh6eWLhW54IKSY+68s/Q5ixeL1Kkj0rOnrcaK/+Tn2/NXr7bHrVxpK7ZRo0oPI40ZU3a7Nm+2FeWYMXr4/cxrhRKrNu7cqavTKlVEmje3lfzLL9tRgn797DXfeKPstqJ86LuR9d3UVPtb3KpVIg89JLJ9u50MO2RIyW9nx46V3V6Ej74b+etusWnTRP76V5G5c0Uuv9xet6io7LbGQ0K/TfDss3ZpS9Wq9r2d1q3ti0SxqlXtezpn2r5d5NAhkQYN3Nf89lv7+NVX9rFly9Jfz86270WdS/Gw2c9/HuzvcbaKaGOxadPs+2nbt9sOL2JfULt3F7nrLjvkVjWhe0Fyou+Wv43FJk2yL9ZPPGH7sYgdqh0xQmT27JL+jOii75a/jWfr0KHkv3/9azv59dZbRV57LbzrVISE/mfg0ktLZrW6VK9eupOK2AkiDRqIzJ/vPicRliNVZBufe85OADr7hfOXv7RzCHbuFGnRInr3g0XfjVxamsicOSKPP26XauXk2H+kbrrJPnf029ig78ZGWpp93Z02zY5qJdoE7oQuBsqjeXM7zHPFFed+svPy7OP27Xa5R7HCQj2z1HUPETsZpEeP0MeFGrqqiDYW27fPvbnQTz/Zx0QdsvIRfdctJ8f+EbF9ec0akcsuY2QgkdB3gzl2zM4gOHIk8YqBhJ4zUB5DhtgXjMce018rKipZ1tGjh505+vTT9ptTbObMsu/RsaPdlGPmTL1M5MxrFa+9PfuYWLXRtcSlVSs7s/a770qyU6dEFi2yy4KKf8AQf/Tdsts/fbrI11+LjB1b9rGoOPTd0lnxWw5nOnhQ5PXX7VyMUG9VxFOlGxno1s1OPJo6VeQf/7DvMVarZqu8xYvt++eDBtkhoXHj7HF9+9rlI5s322V39euf+x6pqXZXrn797HtCt91ml7p8/rld8vTuu/a4/Hz7eM89dgJflSp2Qk6s2uha4vLgg/a9qssuE/mv/7LV6P/+r52MNXlyyVIaxB99t3TfffVV++LZtasdBVi50haxd9whcsMNkT3XiC76bum+27u3nVdx2WX2H/5du0RefNEue1y4MLLnOmbivZzBpXiJy8cfhz6moMAuMQrlhReMyc+3S2Jq1zambVtjHnjAmL17S445dcqYRx81plEje9xVVxmzdatdJnKuJS7FPvjAmJ497fUzMoxp186Yp58u+XpRkTGjRhmTnW1MSope7hLNNhoTeonLO+8Y062bMfXr2+UtbdsaM3t26OcO5UffDb+Nxrj77oYNxnTtakxmpjE1ahjTvr3tt2cu90L00HfDb6Mx7r77zDPGdOliX3OrVrVt6dfPmLVrQz938ZZizJkDIQAAwDeVbs4AAAAID8UAAACeoxgAAMBzFAMAAHiOYgAAAM9RDAAA4LnAmw6lBPlYKKAM8VjJSt9FNNB3kayC9F1GBgAA8BzFAAAAnqMYAADAcxQDAAB4jmIAAADPUQwAAOA5igEAADxHMQAAgOcoBgAA8BzFAAAAnqMYAADAcxQDAAB4jmIAAADPUQwAAOA5igEAADxHMQAAgOcoBgAA8BzFAAAAnqMYAADAcxQDAAB4jmIAAADPUQwAAOA5igEAADxHMQAAgOcoBgAA8FzVeDcgGaSlpansnnvuUdkFF1ygsjp16qjs6quvdt4nIyNDZTVq1FDZ448/rrKZM2eq7Pjx4877AEBl4XqNvfnmm1X2yCOPOM+vX7++ylJT9e/J+/btU1nXrl1Vtm3bNud9Eh0jAwAAeI5iAAAAz1EMAADgOYoBAAA8l2KMMYEOTEmJdVtiJjc3V2U5OTkqc01EEREZMGCAyu68885A93Y9bwGf8rBcccUVKtuwYUPU7xOpWPzdy5LMfTfRuH6WREQGDRqkssGDB6uscePGKmvSpEnkDasA9N34c03cHjVqlMqaNWsW0X2Cvm737t1bZStWrIjo3rEQpO8yMgAAgOcoBgAA8BzFAAAAnqMYAADAc5VuB8Lnn39eZX369FFZ3bp1VVazZs1YNKlC3HTTTSpLxAmESB5DhgxR2ZgxY5zHdurUqdz3cU1K3L17d7mvh8phwYIFKnNNSnVNjtu0aZPKnnzySed99u/fr7LJkyerLD8/33l+ZcHIAAAAnqMYAADAcxQDAAB4jmIAAADPUQwAAOC5pN2OONRM+USb8RnOdsTHjh1TWfXq1VX2008/qaxqVb0w5MSJE0GaKCIiy5YtU9mNN94Y+Pyg2NI1/u69916VzZgxIw4tCX3vsWPHxqEl50bfrVh79+5V2Z49e1S2Zs0alU2aNEllR44ccd5n2rRpKrv//vtV9v3336use/fuKtu6davzPvHEdsQAAKBMFAMAAHiOYgAAAM9RDAAA4Lmk2I64Tp06KqtXr14cWlLiwIEDKtu2bZvK1q5dq7ItW7Y4r+k63/VZ761atVLZlClTVJaenu68j0vnzp1Vlp2drbLCwsLA10TFufzyy535+vXry31N17n33Xef81jXdsRBJyUuXrw4vIbBC7Nnz1bZe++9p7KjR4+qzDVZ0DVRUMTdp3/88UeVDRw4UGWJOFmwvBgZAADAcxQDAAB4jmIAAADPUQwAAOC5pNiB0DWR5I477ojoml999ZXKXJP9Qt0/6ATCcDRv3lxlo0ePVplrZ8BYTKhs0aKFynbu3BnRNdnFLXKR7iC4e/dulY0bN05lixYtCnzN3Nxcle3atSvQucny/aHvxl+VKlVU1qZNG5VNnDhRZTfccEPg+7gmtcZiR9aKwg6EAACgTBQDAAB4jmIAAADPUQwAAOC5hNuB0LXboGt3s1BcEyWee+45lT3yyCMqO3z4cOD7BOX6COJmzZo5j3377bdVlpeXF/U2uZw6dUpl8ZgwhdJcOwuGM1nQtYvg0KFDVeaaVBiOdevWRXQ+cLaLL75YZddff73KXLuvuoTzehbpROlkxMgAAACeoxgAAMBzFAMAAHiOYgAAAM9RDAAA4LmEW01w6NAhle3YsUNlrpmmIiLHjx9X2fz581UW6cqBpk2bquzKK69U2f3336+yiy66KKJ7x8K8efNU5tqyGRUr6MqBUMeNHTs2ms1xboUs4t6O2CWclRCofLKyslR28803O491rRJwrc4Kukog1OuZa8XWb37zG5U99dRTKvv6668D3TsZMDIAAIDnKAYAAPAcxQAAAJ6jGAAAwHMpJuDsi3h+rnZBQYHK5s6dG/j8v/3tbypzbcl64MAB5/kdOnRQ2Ysvvqiytm3bqsz1vMV7m1/XJK6pU6eqLNTzEQk+Ez48QZ+vSP+OQ4YMUdmgQYNUNnjw4MDXdG2F3Llz5/AalkDou5G79tprVbZs2bLA5584cUJlru3mX375ZZV99913zmtu2bJFZa6JjtOmTVPZww8/7LxmognSdxkZAADAcxQDAAB4jmIAAADPUQwAAOC5pJhAWLNmTZWFmkDomgjlsnz5cpW1adPGeWz9+vVVVqtWrUD3icUEQteuV4sXL1bZnDlznOe7Prv+yJEjEbUpKCZhhSfS58s1ia9Tp04RXTOoJk2aqMzV95IFfTdyrVq1UtmIESMCnz99+nSVFRYWRtSmvXv3qiwnJ0dlromGHTt2jOjeFYUJhAAAoEwUAwAAeI5iAAAAz1EMAADguaSYQBiOzz77TGWtW7eOQ0us1FRdb50+fdp57J49e1Tm2hlw1qxZkTcsTpiEFZ6///3vKquoCYDhcLXpww8/jENLYoe+Wzm5JmQ3bNhQZa6PWn711Vdj0qZoYwIhAAAoE8UAAACeoxgAAMBzFAMAAHiuarwbEG3du3dXmWtiXkX58ccfVbZgwQLnsWPGjFFZRe0MiMTk+shf1y6bixYtcp4f9Nigk+NcOxqKVL7Jgqh8MjMznXmVKlVUdvLkSZXF4iPdEwkjAwAAeI5iAAAAz1EMAADgOYoBAAA8RzEAAIDnKt12xHPnzlVZQUFBHFpi7dy5U2UtWrSo+IYkCLZ0jb/c3FyV7dq1K9C5Pj+X9N3k9sYbbzjzvn37quzbb79V2fnnnx/tJlUYtiMGAABlohgAAMBzFAMAAHiOYgAAAM9Vuu2IBw8eHO8mAAlt3bp1gY6bMWNGjFsCxIZrsl+HDh0Cn//yyy9HsTXJgZEBAAA8RzEAAIDnKAYAAPAcxQAAAJ6rdDsQHj58WGXp6emBzj1x4oQzHzFihMoGDhyoMtdOVqdOnVLZ0KFDnfdZvnx5WU1MeuziVrEuv/xyla1fvz7QuU2aNFHZ7t27I25TsqLvJqaLL75YZe+9957K6tat6zz/k08+Udk111yjsqNHj4bfuATBDoQAAKBMFAMAAHiOYgAAAM9RDAAA4LlKtwNhJKpVq+bMhw8frrI///nPKuvatavKGjRooLJp06Y57+Oa2HXw4EHnsUAQQXcR7NSpk8p8nizom+rVq6vMNbFu2bJlzvPHjx8f9Ta5NGzYUGULFixQWWZmZuBrPvbYYypL5smC5cXIAAAAnqMYAADAcxQDAAB4jmIAAADPVboJhCNHjlTZvHnzAp2bmuqujXr37h0oC8q1Y5aISOPGjVXGBEIEkZub68xdEwOBs3Xr1k1lbdq0Udlzzz1XEc0REffrpGuyoKudrh333njjDed9Vq1aFX7jKiFGBgAA8BzFAAAAnqMYAADAcxQDAAB4jmIAAADPVbrVBK4Zo8uXL1dZJKsBgEQzZsyYwMe6thn+8MMPo9gaJJuNGzeqbMeOHSp7+umnnefXq1dPZR9//HFEbXJt+e7aZti1cmDJkiUqGzFihPM+x48fL0frKh9GBgAA8BzFAAAAnqMYAADAcxQDAAB4LsW4Zl+4DkxJiXVbYqZOnToqmzZtmsoKCgqc56elpZX73q7nrbCw0HnspZdeqrJdu3aV+96JKGB3i6pk7rtBhfO8zpgxQ2Vjx46NZnMqJd/67oABA1QWamv39PR0lcXi+XI9H0uXLlXZbbfdprIjR45EvT3JIsj3gpEBAAA8RzEAAIDnKAYAAPAcxQAAAJ7zYgJhUM2bN3fmXbp0UdnAgQNV1rdvX5W5Jq1MmDDBeZ9Zs2aV1cSk59skrFjIzc1VWTgTTTt16qQydiAsG31XJDs725mPGzdOZX369FFZmzZtIrp///79VbZq1SqVsatgaUwgBAAAZaIYAADAcxQDAAB4jmIAAADPMYEQFYpJWJEbMmSIyhYuXOg8dv369Srr3Llz1NvkA/oukhUTCAEAQJkoBgAA8BzFAAAAnqMYAADAcxQDAAB4jtUEqFDMyEayou8iWbGaAAAAlIliAAAAz1EMAADgOYoBAAA8RzEAAIDnKAYAAPAcxQAAAJ6jGAAAwHMUAwAAeC7wDoQAAKByYmQAAADPUQwAAOA5igEAADxHMQAAgOcoBgAA8BzFAAAAnqMYAADAcxQDAAB4jmIAAADP/T/BZG/lZnI7eAAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgMAAAGFCAYAAABg2vAPAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8g+/7EAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAn90lEQVR4nO3dfZjNdf7H8fdoDMZ9KMpNSdqt3CxqVK5QZAmx2VBaadVsP8LVtqWbVcmicle5S5tKrNtU7lLa1Q2lclcXsUkRFUYhabAzPr8/PtdcY7w/x3zPnHPmnDOf5+O6XJOX7817znyc3r7n8/18U4wxRgAAgLdKxbsAAAAQXzQDAAB4jmYAAADP0QwAAOA5mgEAADxHMwAAgOdoBgAA8BzNAAAAnqMZAADAczQDDuedJ3Lbbfm/f/ddkZQU+zVRnFojIMLYRfJi7MZXQjYDL71kB0Her7JlRRo2FBk4UGTv3nhXF9yyZSKPPhrfGk59LU/+tWdPfGsriRi70bVunUjnziI1a4pUqCDSuLHIM8+I5ObGu7KSh7EbPcn4vpsa7wJOZ/hwkfPPFzl6VGTVKpEpU+wPetMmkfT04qvj6qtFsrNF0tLC22/ZMpFJk+I/MEXyX8uTVakSl1K8wNiN3Lp1IldeKXLhhSL3329ftzffFBk8WGT7dpGnn45fbSUZYzd6kul9N6GbgY4dRVq0sP/dv79ItWoi48aJvPGGSO/eevsjR0TKl49+HaVK2S45mZ38WiL2GLuRe+45+/X990XOPNP+d2amSOvW9l9eNAOxwdiNnmR6303IjwlCueYa+/Wbb+znNhUq2H8hdOokUrGiyC232D8/cUJkwgSRSy6xg+nss+2byIEDBY9njMiIESK1a9uOt21bkc2b9XlDfXb18cf23FWr2r8MjRvnv0HddpvtTkUKXiLKE+0aRexrsX176Nfv8GEur8YLYzf8sfvzz/b4p/5LqlYtkXLl3MdB9DF2/XjfTegrA6fKe8GrVbNfc3JEOnQQadVKZMyY/EtYmZn2Xw79+okMGmQH8cSJIhs2iKxeLVK6tN1u2DD7A+/Uyf5av17kuutEjh8vvJYVK+xnmbVq2cuWNWuKbNkismSJ/X1mpsj339vtXnlF7x+LGq+91n7dsUP/Wdu2Ir/8Yi+5deggMnasvfyK4sHYDX/stmkjMneuPd899+R/TLBwochTTxX+fSI6GLuevO+aBPTii8aIGPPOO8ZkZRmza5cxc+YYU62aMeXKGbN7tzF9+9pthg4tuO8HH9h81qyC+fLlBfN9+4xJSzPm+uuNOXEif7sHH7Tb9e2bn61cabOVK+3vc3KMOf98Y+rVM+bAgYLnOflYAwbY/U4VixqNsfXUq1cwmzvXmNtuM+bll4157TVjHn7YmPR0Y6pXN+bbb3VtiAxjN/wajXGP3ZwcYwYONKZ0abuPiDFnnGHMlCm6LkSOsRt+jcaUnPfdhG4GTv1Vr579wRmTPyh37iy476BBxlSubH+gWVkFf1WoYEz//na7f/3L7p93vDz79hU+KD/91P5+/PjTfx+hBmUsagzHBx8Yk5JiTGZm0fZHaIzd8Gs8nfHjjenc2b6pzp1rTLduxqSm2jdYRBdjN/waw5Ho77sJ/THBpEn21pbUVPvZzkUX2UkleVJT7Wc6J9u2TeTQIZGzznIfc98++3XnTvv11Es2NWrYz6JOJ++y2aWXBvs+TlUcNZ5Oq1YiGRki77xT9GPg9Bi7Ra8xz+jR9rPgbdvs59QiIjfdZC+9DhhgLxenJvQ7WHJi7Ba9xtNJ9PfdhP6rdPnlp5+JWaZMwUEqYieInHWWyKxZ7n1q1IhefUWVCDXWqSPy3//G/jy+YuxGbvJkO3ktrxHI07WrnUOwY4dIgwbROx8sxm7sJPL7bkI3A0VxwQW287rqqtPPOK5Xz37dtk2kfv38PCtLzyx1nUPE3nfbrl3o7U6exVrcNRbm668T4y8o8jF2C9q71z0L+3//s19zcoIdB7HH2A0mkd93k+rWwiBuusm+gTz+uP6znByRgwftf7drZ2eOPvus/WQsz4QJhZ+jWTO7kMSECfnHy3PysfLuvT11m1jV6LrFJStLb7dsmV3Q5fe/dx8H8cHYLZg1bGhnhf/4Y36Wmysyb569pS3vfw6IP8ZuwSwZ33dL3JWB1q3t7SOjRols3GhvByld2nZ58+fbzyB79LDd2b332u06d7a3j2zYYG9dql799OcoVcquytWli0jTpvY2lVq1RLZutfeivvWW3a55c/t10CB7W8kZZ4j06hW7Gl23uFx5pcjvfmcv+1WubG+RmT7dXq568MHIXmtEF2O34NgdOlSkTx/7Oeudd9p/zc2ebd9QR4zIvw0M8cfYLQHvu/GeweiSN6v1009Db9O3rzHly4f+82nTjGne3N4SU7GiMY0aGXPffcZ8/33+Nrm5xjz2mDG1atnt2rQxZtMmO3v2dLNa86xaZUz79vb45csb07ixMc8+m//nOTnG3H23MTVq2Fmkp77a0azRGPctLg89ZEzTpnYWbenSxtSta8xddxmzZ0/o1w5Fx9gNv0Zj3GPXGDuju3Vre0tWWpo9z9SpoV87FB1jN/wajSk577spxpx8IQQAAPimxM0ZAAAA4aEZAADAczQDAAB4jmYAAADP0QwAAOA5mgEAADxHMwAAgOcCr0CYEmrBZyAM8VjWgrGLaGDsIlkFGbtcGQAAwHM0AwAAeI5mAAAAz9EMAADgOZoBAAA8RzMAAIDnaAYAAPAczQAAAJ6jGQAAwHM0AwAAeI5mAAAAz9EMAADgOZoBAAA8RzMAAIDnaAYAAPAczQAAAJ6jGQAAwHM0AwAAeI5mAAAAz6XGuwAAsXPdddepbOjQoSpr27atyk6cOBH4POPHj1fZunXrVDZ79uzAxwRQfLgyAACA52gGAADwHM0AAACeoxkAAMBzKcYYE2jDlJRY1xJ31atXd+Z33HFHMVeSb8iQISoLVeepZs6c6cyfeuoplW3atCmsuooq4HCLKh/Gbvfu3Z35v/71L5WVLl1aZa7XKNKfVW5ursqGDRumsieeeCKi8xQXxi6SVZCxy5UBAAA8RzMAAIDnaAYAAPAczQAAAJ7zdgLhwIEDVTZy5Ejntunp6UU+TywmZkVq3759Knv00UdVNm3atKifm0lYkatcubLKFi9e7Nz2yiuvDHTM4hqnx48fV9maNWtUds0110T93JFi7JZMqal6Id60tDSV9ezZU2VlypQJfB7XOP/8889VFs7Kn0ExgRAAABSKZgAAAM/RDAAA4DmaAQAAPOfFI4xr1aqlsszMTJVFMlEwmVSoUEFlTZs2Lf5CUKiqVauq7OWXX1ZZ0ImCoXz55Zcq27x5s8pGjx7t3P/w4cMqu+KKK1T2z3/+U2X169dXWd26dZ3n+fbbb505UJgpU6Y48xYtWqisWbNmsS5HRNyrwY4ZM0Zl+/fvj3ktXBkAAMBzNAMAAHiOZgAAAM/RDAAA4DmaAQAAPFfi7iY455xzVDZ37lyV/fa3vw18zOzsbJW99dZbgfYtrmVed+3apbKpU6c6t83JyVHZ9u3bo14TInfhhReqrFOnToH3P3LkiMquvfZale3Zs0dlu3fvDnwel9q1axd5u9atWzu3feWVVyKqCfHlWvr3+uuvd247YsQIlb399tsqW7FihcpmzpypMtcy3iIipUoV/d/ErvdS1104odxyyy0qa968ucrat28fXmFFwJUBAAA8RzMAAIDnaAYAAPAczQAAAJ5L2gmEriWGRdyTBV3Lorq4JluJiAwePFhlL730UqBjAvH0/PPPq2zt2rXFcu46deoUy3mQPFq2bKmyhQsXBt7/4osvVplrAqpromKoiYKuCd0//fSTyubMmaOyAwcOqOyRRx5xnsfl7LPPVllaWlrg/aOJKwMAAHiOZgAAAM/RDAAA4DmaAQAAPJe0Ewhnz57tzINOFnQJ9ax0JgsiXlwrlIWjuFaWdE0Mcz2X3eXYsWMqO3ToUMQ1Ib5cq+aNGzcuomO6Jnm7JuwNGDBAZRkZGc5j5ubmqmz58uVFqC58e/fuLZbzBMGVAQAAPEczAACA52gGAADwHM0AAACeS4oJhH379lWZ6zGPkXr33XedeYMGDVT21VdfRf38wKnCedS2S6jHthZVenq6M7/kkktUVqVKlUDH/Prrr1W2aNGisOpCfLVt21Zl8+bNU1mlSpUCH9M1Ljp27Kiyb775RmWuSYFLly4NfG4fcWUAAADP0QwAAOA5mgEAADxHMwAAgOdoBgAA8FyKcT3M2bVhSkqsawnJ9Uz2fv36Fdv5f/3110DnX7Nmjcq+++67mNSUrAIOt6iK59iN1KBBg1QWzpKuhw8fVlm9evWKXM/06dOdebdu3Yp8zM8++0xlsbhbKFKMXZHSpUs787lz56rshhtuiOhcvXr1UpnrPdblp59+UplrKWNfBBm7XBkAAMBzNAMAAHiOZgAAAM/RDAAA4LmkmEB45513qmzixInObUuVSqz+ZsqUKSoLNQlm4cKFKsvOzo56TfHEJKzwXH755Sr78MMPo34e12sUi5/VCy+8oLKxY8eq7Msvv4z6uSPF2A09UfTVV18t3kIKsXXrVpWNHDnSue2sWbNiXU7cMYEQAAAUimYAAADP0QwAAOA5mgEAADyXFBMIXQYMGODMK1SoUORj1qhRw5kPGTKkyMcMZ2LWpk2bVNa+fXuVZWVlFbmeeGMSVmjnnXeeylasWKGy+vXrR/3crom3J06ciOiYO3bsUNl1112nsu3bt0d0nuLC2BW56KKLnPmMGTNUdtlll0V0rkOHDqnM9R551VVXqSyc992lS5eq7LHHHlPZ2rVrnfsnAyYQAgCAQtEMAADgOZoBAAA8RzMAAIDnknYCYbx17dpVZRkZGSp78MEHVRbpxKz7779fZWPGjInomMWFSVihvffeeypzTY5y+eijj5z5FVdcEWj/WKxA+N///ldlHTp0UNnu3bsjOk9xYeyGVq1aNZU99NBDKnM90t31+GMRkePHj6vM9WjimjVrBsoWLFjgPE+dOnVU9uOPP6qsRYsWKvv222+dx0w0TCAEAACFohkAAMBzNAMAAHiOZgAAAM8xgTDGKlasqLL58+c7t23Xrl2gYybzxCwmYYnUrVvXmf/73/9WmWv89OnTR2VbtmxxHnP06NEq6927t8pcr9EXX3yhsnr16jnPk56e7sxP9dlnn6mse/fuKkvEiVmM3dBq166tMteE6ng+6njevHnO/MYbbwy0/6RJk1Q2aNCgiGoqLkwgBAAAhaIZAADAczQDAAB4jmYAAADP0QwAAOA57iaIg/LlyzvzOXPmqKxjx46Bjumaie66wyDefJuR7bpz4LXXXnNu26RJE5V98sknKrvyyisDn/+MM85QWYMGDQLte/DgQZVVqFDBuW1qaqrKXMvMXnrppSr74IMPVNa2bdsAFRYv38ZuOFx3E2RlZans2LFjxVGOdO7cWWUvvPCCc9vq1asHOqZrafknnngivMLihLsJAABAoWgGAADwHM0AAACeoxkAAMBzetZPkrjkkkuc+ebNm4u5kvAdOXLEmbuWKQ46gdC1bC3ir02bNipzTRQUcT+rfeTIkRGdPzc3V2Wu5ayD2rt3b+Btjx49Gmi79evXF7UcRMnf//53lfXv319laWlpzv3/8pe/qGzp0qWRFxbg/F26dFGZaxnuoBMFRUQmT56ssqeeeirw/smIKwMAAHiOZgAAAM/RDAAA4DmaAQAAPJcUEwj/+Mc/qqxdu3bObTMzM2NdTsTq1KnjzIcMGVK8hSDmzj333MDbbtiwQWVLliyJZjkx06pVK5U1bNgw0L6hJgOj+LhW7HOtKhjKwoULVeaazO2a0BoO10qXF198scpcKzeGWoXPNdF17dq1Kjtx4kSQEpMWVwYAAPAczQAAAJ6jGQAAwHM0AwAAeC4pJhA2a9ZMZZ06dXJu27JlS5WtWbMm6jUFdfnll6ts2rRpzm1dj3cNavfu3UXeF7FTqVKleJcQVaEef3zfffepzPW9f/jhhyrr169f5IUhIsOHD1dZ3759VXbjjTcGPmaiTQwNNRl3woQJKlu5cmWMq0k8XBkAAMBzNAMAAHiOZgAAAM/RDAAA4LmkmEBYoUIFldWqVcu5resxwJ988onKpk+frrLt27cHrqlr164qy8jIUFm3bt1UFmolrKA+//xzlQ0YMCCiYyI2tmzZEnjbMmXKBMqOHTsWUU0urkdgjxkzRmU333yzc/9y5coFOs8jjzyish9++CHQvogd1+OG33zzTZW5xqOISOvWrVVWr169yAsrotWrV6ss1OPtI30/Lim4MgAAgOdoBgAA8BzNAAAAnqMZAADAczQDAAB4LinuJli3bp3KQj0X23WXwQ033BAoS0R79+5V2TPPPKOyrKys4igHYfrf//6nslDPRW/VqpXKZs+erbJYLD3dvHlzlbnujgnFdcfOK6+8orJt27aFVxjixjVOs7OzndsuX7481uUgxrgyAACA52gGAADwHM0AAACeoxkAAMBzKSbgWowpKSmxriUsrmdti7iXO61bt26sywnJ9bqFWk72o48+UlmPHj1UduDAgcgLi5N4LP2ZaGP3jjvucOYPPfSQymrXrh3rckTE/Rq5flajRo1y7u96JvyPP/4YcV2JhLGLZBVk7HJlAAAAz9EMAADgOZoBAAA8RzMAAIDnknYCYSgNGzZUWffu3VV2++23q+yCCy6Iej0PP/ywylwrKoqIrFixIurnTzRMwkKyYuwiWTGBEAAAFIpmAAAAz9EMAADgOZoBAAA8V+ImECKxMQkLyYqxi2TFBEIAAFAomgEAADxHMwAAgOdoBgAA8BzNAAAAnqMZAADAczQDAAB4jmYAAADP0QwAAOA5mgEAADxHMwAAgOdoBgAA8BzNAAAAnqMZAADAczQDAAB4LsXE4yHdAAAgYXBlAAAAz9EMAADgOZoBAAA8RzMAAIDnaAYAAPAczQAAAJ6jGQAAwHM0AwAAeI5mAAAAz9EMAADgOZoBAAA8RzMAAIDnaAYAAPAczQAAAJ6jGQAAwHM0AwAAeI5mAAAAz9EMAADgOZoBAAA8RzMAAIDnaAYAAPAczQAAAJ6jGQAAwHM0AwAAeI5mAAAAz9EMAADgOZoBAAA8RzMAAIDnaAYAAPAczQAAAJ6jGQAAwHM0AwAAeI5mAAAAz9EMAADgOZoBh/POE7nttvzfv/uuSEqK/ZooTq0REGHsInkxduMrIZuBl16ygyDvV9myIg0bigwcKLJ3b7yrC27ZMpFHH413FSIrVoi0aiWSni5StapIjx4iO3bEu6qSibEbXYzd4sPYjZ733xfp2lWkTh37OtasKfL734usXh3fuk4nNd4FnM7w4SLnny9y9KjIqlUiU6bYH/SmTfbNobhcfbVIdrZIWlp4+y1bJjJpUnwH5pIlIjfcINKsmcjo0SI//yzy9NP2DXbDBpEaNeJXW0nG2I0cYzc+GLuR+/JLkVKlRP7yF9sIHDggMnOm/Z6WLrWNQaJJ6GagY0eRFi3sf/fvL1Ktmsi4cSJvvCHSu7fe/sgRkfLlo19HqVK2u0tG998vUr++7Ujz/lJ16ZL/Bjt2bHzrK6kYu5Fj7MYHYzdy/fvbXyf7v/+z43nChMRsBhLyY4JQrrnGfv3mG/u5TYUKItu3i3TqJFKxosgtt9g/P3HCvuCXXGIH09lni2Rm2u7sZMaIjBghUru27XjbthXZvFmfN9RnVx9/bM9dtar9y9C4sf2Xi4itb9Ik+98nX3rLE+0aRexrsX17/u9/+knkiy9Euncv2F03aSLy29+KzJnjPg6ij7HL2E1WjN3wxm4o6en2atbBg4VvGw8JfWXgVHkveLVq9mtOjkiHDvay4Zgx+ZewMjPt51/9+okMGmQH8cSJ9tLi6tUipUvb7YYNsz/wTp3sr/XrRa67TuT48cJrWbFCpHNnkVq1RAYPtpeCtmyxlzYHD7Y1fP+93e6VV/T+sajx2mvt17zPVI8ds1/LldPbpqfbwb1nj60dscXYZewmK8ZueGP3ZD//bPfZv19kxgz7UcuDDxb+fcaFSUAvvmiMiDHvvGNMVpYxu3YZM2eOMdWqGVOunDG7dxvTt6/dZujQgvt+8IHNZ80qmC9fXjDft8+YtDRjrr/emBMn8rd78EG7Xd+++dnKlTZbudL+PifHmPPPN6ZePWMOHCh4npOPNWCA3e9UsajRGFtPvXr5v8/NNaZKFWOuvbbgdvv3G1O+vD3G2rW6PhQdYzf8Go1h7CYCxm74NRqjx+7JOnSw+4jYY2ZmGpOd7d423hL6Y4J27exllTp1RHr1spenXntN5Nxz87e5666C+8yfL1K5skj79rYby/vVvLndf+VKu90779iO7e67C15GGjKk8Lo2bLAd5ZAhIlWqFPyzk48VSqxq3LGjYHdaqpTthP/9b5EHHhDZtk1k3TqRm27K73CzswuvF+Fj7DJ2kxVjN7Kxe7LRo0XeflvkhRdEWra0x83JKbzWeEjojwkmTbK3tqSm2s92LrrIvknkSU21n+mcbNs2kUOHRM46y33Mffvs15077dcLLyz45zVq2M+iTifvstmllwb7Pk5VHDXmGT7cDvgnn7QDU8Re7vrzn0WmTrV/CRB9jN2i15iHsRsfjN2i13iqpk3z/7tPHzv59bbbRBYsCO84xSGhm4HLL8+f1epSpkzBQSpiJ4icdZbIrFnufRLhdqTirDEtTeSf/xT5xz/s7S5nn23/ot98s33tGjSI3rmQj7EbOcZufDB2YyMtza49MHq0varlmg8TTwndDBTFBRfYyzxXXXX6F7tePft12zZ7u0eerCw9s9R1DhE7GaRdu9Dbhbp0VRw1nurss+0vEZHcXDtDNyODf10lEsauG2M38TF2g8nOtjMIDh9OvGYgoecMFMVNN9k3jMcf13+Wk5N/W0e7dnbm6LPP2h9OngkTCj9Hs2Z2UY4JE/RtIicfK+/e21O3iVWNQW9xGTNG5IcfRP7618K3RfFh7BZeP2M3MTF2C2Z5Hzmc7OBBkVdftXMxQn1UEU8l7spA69Z24tGoUSIbN9rPGEuXtl3e/Pn2ftQePewloXvvtdt17mxvH9mwQeTNN0WqVz/9OUqVsqtydeliPxPq18/e6rJ1q73l6a237HbNm9uvgwbZW3HOOMNOyIlVja5bXGbOtAPw6qvtv6TeeUdk3jy7IMaNN0b2WiO6GLuM3WTF2C04djt2tPMqMjLs//i//VbkxRftbY9z50b2WsdMvG9ncMm7xeXTT0Nv07evvcUolGnTjGne3N4SU7GiMY0aGXPffcZ8/33+Nrm5xjz2mDG1atnt2rQxZtMme5vI6W5xybNqlTHt29vjly9vTOPGxjz7bP6f5+QYc/fdxtSoYUxKir7dJZo1GuO+xeXjj425+mpjqlY1pmxZY5o0MWbq1IK3zCB6GLvh12gMYzcRMHbDr9EY99idONGYVq2MqV7dmNRUW0uXLsa8/37o1y7eUow5+UIIAADwTYmbMwAAAMJDMwAAgOdoBgAA8BzNAAAAnqMZAADAczQDAAB4LvCiQylBHgsFFCIed7IydhENjF0kqyBjlysDAAB4jmYAAADP0QwAAOA5mgEAADxHMwAAgOdoBgAA8BzNAAAAnqMZAADAczQDAAB4jmYAAADP0QwAAOA5mgEAADxHMwAAgOdoBgAA8BzNAAAAnqMZAADAczQDAAB4jmYAAADP0QwAAOA5mgEAADxHMwAAgOdoBgAA8BzNAAAAnqMZAADAczQDAAB4LjXeBQAASp5u3bqp7NVXX1VZbm6uc/8lS5aobPHixSpbsGCByo4dO6ay48ePO88DiysDAAB4jmYAAADP0QwAAOA5mgEAADyXYowxgTZMSYl1LXHXu3dvZ16zZs1A+7du3VplGzduVNnWrVud+8+ZMyfQeZJZwOEWVT6M3XBUqVJFZf3791eZa5yOHTvWecwKFSqorGzZsiqbMGGCysaMGaOy7Oxs53niibEbnltuuUVlo0ePVtm5554b+Jiu18P1c1m9erXKQr2/Tp48OdAxk1mQ74crAwAAeI5mAAAAz9EMAADgOZoBAAA85+0Ewo8//lhljRo1cm6blpYW6JhBJ7eEWgnr8ccfV9moUaMCnTtZMAmreLVs2VJly5cvV1nlypWLoxynJ598UmVDhw51bhvPiV2M3ci5vp+ePXs6tx00aJDKLrzwQpVVq1YtopoGDBigsilTpkR0zETDBEIAAFAomgEAADxHMwAAgOdoBgAA8BzNAAAAnitxdxOcd955KuvVq5fKhg0bprJQdw24no29fv36QPW4Zro2bNjQua3rLoPbb79dZcm8bDEzsmOjVq1aznzLli0qc905cOLECZV9+umnKhs/frzzPL/88ovKGjdurLIHHnhAZRUrVlRZly5dnOdxPeO+uDB2469+/foqu+aaa1TmWuK6UqVKzmPOnj1bZa6llJMZdxMAAIBC0QwAAOA5mgEAADxHMwAAgOdS411AUaWmukt3TVByPavdNaHik08+cR7TtUzwm2++WViJIiJSu3Ztlc2fP9+57WWXXaayv/3tbypzLSd78ODBQPUg+aWnp6tswYIFzm1dkwWPHj2qMteE2qeeeqoI1eVbunRpoHOPGzdOZTfffHPgY5a0Z88jtK+//lplrgmo5cuXD3zM9957L6KaSgquDAAA4DmaAQAAPEczAACA52gGAADwXNKuQOh6BrWIyNNPP60yV+0bNmxQWahVz3744Ycwqzs91zPmRURWrVoVaH9X7e3atVPZoUOHwiusGLCKW3jKlSunMtfqaM8//7xz//3796vMNaH2jTfeKEJ14XNNVHzssccC7++aLOZa/TAWGLvx51pp8/XXX1eZazL2jBkznMfs16+fykrapFRWIAQAAIWiGQAAwHM0AwAAeI5mAAAAzyXFBELXhLvVq1cH3r9UKd3zuFYG/O6778IrLMoGDhyoMteEyGT5flyYhBWesWPHquyee+5RmesRxCLuyYIvvvhioHOXLl1aZX369HFu+80336jMNflx4sSJKnM9ltb12HAR9yPBjxw54tw22hi7xcu1iuCiRYtU1rZtW5Vt3rxZZTfccIPzPK5VDUsaJhACAIBC0QwAAOA5mgEAADxHMwAAgOdoBgAA8FxqvAsIomnTpioLZ2bvc889p7I9e/ZEUlJM7NixQ2Wu79M1c3zatGkq+9Of/uQ8z48//hh+cYi55s2bq+zPf/5zoH1DLUcc9M6BOnXqqOzJJ59UWa9evQIdL1Khvp/iunMAxadq1arOfOHChSpr06aNyrKyslTWs2dPlflw10AkuDIAAIDnaAYAAPAczQAAAJ6jGQAAwHNJMYHw1ltvjWj/UaNGqSw3NzeiY7qcc845KnNNAGzdurVz/2eeeabI5+7QoYPKGjRo4NyWCYSJqXfv3iqrXLmyyvbt26ey0aNHBz6Pa5nhefPmqcy1DHhx+fDDD+N2bsSOa0wtXrzYua1r6endu3erzPX/hy+++KII1fmNKwMAAHiOZgAAAM/RDAAA4DmaAQAAPJcUEwgj5VpJ7YEHHlBZqBWqUlP1y5SZmaky17PjXasFNmnSxHmeSPz6668qC/VMeMSXa6VBEZE777wz0P4vvPCCylyrV4biWkWwZs2aKnNNvF2+fLnzmEOGDFFZ9+7dA9Xzn//8R2Xz588PtC8S18svv6yyPn36qKxUKfe/SV0Tndu2bauyr776qgjV4VRcGQAAwHM0AwAAeI5mAAAAz9EMAADguaSYQLho0SKVZWRkBN6/R48eKmvUqJHKli1b5ty/YsWKKnM9WjYlJUVl4TxqORKuCY0bN24slnMjPI0bN3bmrnG2c+dOlY0cOTKi87tWG3z77bdVtnfvXpX169fPecwuXboEOrfr0eGPPPKIynJycgIdD4nrN7/5jcrCeY8888wzVbZixQqVzZgxQ2WTJ09WmWs8Ix9XBgAA8BzNAAAAnqMZAADAczQDAAB4LsUEnOHmmvgRT3379nXmAwcOVFmLFi1U5loZMFIbNmxQ2bvvvquytWvXOvefNWtWoPO4VuyqXbu2yr777rtAxytOxTWh8mSJNnZDTcKbPn26yqZOnaqyu+66K+o1uQwbNkxlf//7353bulbpdBk0aJDKnn322fAKixPGbnjKli2rsho1aqisW7duzv3r16+vsq5du6rs/PPPV9mhQ4dUNmHCBOd5hg8frrJ4/KxjKcj3w5UBAAA8RzMAAIDnaAYAAPAczQAAAJ6jGQAAwHNJsRyxi+tZ2SIir7/+uso6deqkMtes1FBcy11+/vnnKvvll19U5prV2rJlS+d5gs5gfe6551TmWuYVcHEtE9uwYUOVue4cCHrXgIjIkiVLVDZ//vzA+yO5HT16VGW7du1SWTh3k7iW4u7Tp4/K/vGPf6jMtey1iPvurFDblmRcGQAAwHM0AwAAeI5mAAAAz9EMAADguaRdjjiZ9erVy5nPnDkz0P4XXHCBylzPvU9ELOka3nLE+/fvV9mqVatUduDAAecxmzRporJLL71UZWlpac79I3HPPfeobPz48VE/T3Fh7CaPDh06qGzy5MnObevWrasy1yTvdevWRV5YnLAcMQAAKBTNAAAAnqMZAADAczQDAAB4LmlXIEwW6enpKvvrX/8aeP+DBw+qLFkmCyJy1atXV1mo57/H04YNG1Q2a9asOFQCiLz11lsqGz16tHNb14qud955p8oyMzMjLyyBcWUAAADP0QwAAOA5mgEAADxHMwAAgOeYQBhj119/vcp+97vfBd5/xIgR0SwHCSArKyui/b///nuVuR4NKyKSkZGhskWLFqksOztbZT179gxc0+zZs1W2b9++wPsDsbZ3797A21599dUxrCQxcWUAAADP0QwAAOA5mgEAADxHMwAAgOeYQBhjY8eOVRmPJfXb0qVLnbnrkb+uiUy33nqrylwTAEVEGjVqpLJNmzap7KGHHnLuH9TixYsj2h9+WLBggcqGDBni3Hb37t1RPXelSpUCb/vZZ59F9dzJgCsDAAB4jmYAAADP0QwAAOA5mgEAADxHMwAAgOe4myDGjDGBMhGRgwcPquz999+PdkmIs1A///HjxwfKwrFx48aI9j/V9OnTnfm2bduieh6UTBUrVlRZqDH68MMPq2zmzJkqO/PMM1XWvn17lY0bN855Htffx2XLljm3Lcm4MgAAgOdoBgAA8BzNAAAAnqMZAADAc0wgTCBVqlRRmWs52vXr1xdDNYD21VdfOfPc3NxirgTJ6A9/+IPK1qxZ49x28uTJKhsxYoTKypQpo7Ly5csHrunxxx9X2YwZMwLvX1JwZQAAAM/RDAAA4DmaAQAAPEczAACA55hAmEBck7AOHz4ch0rgm61bt6rsl19+iUMlKMmOHDmisoyMDOe2ffr0UVmHDh1UVrVqVZXt2rVLZU8++aTzPF988YUz9w1XBgAA8BzNAAAAnqMZAADAczQDAAB4LsWEep7qqRumpMS6lhJp586dKjv33HOd206aNEllgwcPjnpN8RRwuEUVY7do7r33XpVt377due1rr70W63LijrGLZBVk7HJlAAAAz9EMAADgOZoBAAA8RzMAAIDnaAYAAPAcdxOgWDEjG8mKsYtkxd0EAACgUDQDAAB4jmYAAADP0QwAAOA5mgEAADxHMwAAgOdoBgAA8BzNAAAAnqMZAADAc4FXIAQAACUTVwYAAPAczQAAAJ6jGQAAwHM0AwAAeI5mAAAAz9EMAADgOZoBAAA8RzMAAIDnaAYAAPDc/wMqG5238qPFzgAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 640x480 with 6 Axes>"
       ]
@@ -596,7 +622,7 @@
     "model.set_train(False)\n",
     "for data, label in test_dataset:\n",
     "    pred = model(data)\n",
-    "    predicted = pred.argmax(1)\n",
+    "    predicted = mint.argmax(pred, dim=1)\n",
     "    print(f'Predicted: \"{predicted[:6]}\", Actual: \"{label[:6]}\"')\n",
     "\n",
     "    # 显示数字及数字的预测值\n",
@@ -622,7 +648,7 @@
     "\n",
     "| 香橙派AIpro | 镜像 | CANN Toolkit/Kernels | MindSpore |\n",
     "| :----:| :----: | :----:| :----: |\n",
-    "| 8T 16G | Ubuntu | 8.0.0beta1| 2.5.0 |"
+    "| 8T 8G | Ubuntu | 8.1.RC1 | 2.6.0 |"
    ]
   }
  ],


### PR DESCRIPTION
任务
任务编号：#ICJ8XO
任务链接：[【开源实习】香橙派github仓中的在线推理案例01-quick start基于PyNative模式改写成以mint接口实现](https://gitee.com/mindspore/community/issues/ICJ8XO)
版本信息:
MindSpore 2.6.0 + CANN 8.1.RC1
OrangePi AiPro 8G 8T

实现内容：
1. 香橙派github仓中在线推理案例 01-quick start 基于MindSpore2.6.0的PyNative模式下可以在香橙派开发板正常流畅运行。
 
**PyNative模式**
<img width="1833" height="124" alt="img1" src="https://github.com/user-attachments/assets/b342c280-30d4-41e8-aac4-5edf8e5597f5" />

 **训练正常**
<img width="1781" height="971" alt="img2" src="https://github.com/user-attachments/assets/fb0a1802-f558-4bfa-b4dd-a4c6faa966a8" />

 **推理正常**
<img width="1735" height="775" alt="img3" src="https://github.com/user-attachments/assets/ab873aa1-60ae-4d8c-9354-ac6e2caba773" />
