### PR TITLE
【开源实习】香橙派github仓中的在线推理案例01-quick start基于PyNative模式改写成以mint接口实现

### DIFF
--- a/Online/inference/01-quick start/mindspore_quick_start.ipynb
+++ b/Online/inference/01-quick start/mindspore_quick_start.ipynb
@@ -64,16 +64,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mindspore.set_context(mode=mindspore.PYNATIVE_MODE)\n",
-    "mindspore.set_device(\"Ascend\")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
任务
任务编号：#ICJ8XO
任务链接：[【开源实习】香橙派github仓中的在线推理案例01-quick start基于PyNative模式改写成以mint接口实现](https://gitee.com/mindspore/community/issues/ICJ8XO)
版本信息:
Python 3.9 + MindSpore 2.6.0 + CANN 8.1.RC1
OrangePi AiPro 8G 8T

实现内容：
1. 香橙派github仓中在线推理案例 01-quick start 基于MindSpore2.6.0的PyNative模式下可以在香橙派开发板正常流畅运行。
 
**PyNative模式**
<img width="1840" height="122" alt="aa7190dab11efdccad44f02f86641a9" src="https://github.com/user-attachments/assets/7b20d2c8-65be-400e-906b-a75d013edae1" />

 **修改为mint接口**
<img width="1835" height="939" alt="cc883bfa0abc795374f60a46e966bad" src="https://github.com/user-attachments/assets/c34e330e-b9fc-4e40-a008-57b26f9bc8d4" />

 **训练正常**
<img width="1835" height="939" alt="cc883bfa0abc795374f60a46e966bad" src="https://github.com/user-attachments/assets/b90f34c1-242d-49fd-823a-9c30ac64685e" />


 **推理正常**
<img width="1812" height="813" alt="df142f394bf74caf1fc057795296ba6" src="https://github.com/user-attachments/assets/0edaa027-d2ff-4e41-8c69-b9f228a2357f" />

