### PR TITLE
【开源实习】香橙派github仓中的在线推理案例06-SSD基于PyNative模式改写成以mint接口实现

### DIFF
--- a/Online/README.md
+++ b/Online/README.md
@@ -34,7 +34,7 @@
 |[ViT](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/03-ViT)| 8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[FCN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/04-FCN)| 8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[ShuffleNet](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/05-ShuffleNet)| 8.0.RC3.alpha002  | 2.4.10| 8T16G |
-|[SSD](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/06-SSD)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
+|[SSD](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/06-SSD)|8.1.RC1  | 2.6.0| 8T8G |
 |[RNN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/07-RNN)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[LSTM+CRF](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/08-LSTM%2BCRF)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[GAN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/09-GAN)|8.0.RC3.alpha002  | 2.4.10| 8T16G |

--- a/Online/inference/06-SSD/mindspore_ssd.ipynb
+++ b/Online/inference/06-SSD/mindspore_ssd.ipynb
@@ -58,33 +58,57 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c410a2d2",
+   "id": "270176ff-5f11-4793-8c87-d55042ec4e18",
    "metadata": {},
    "source": [
     "## 设置运行环境\n",
     "\n",
     "由于资源限制，需开启性能优化模式，具体设置如下参数：\n",
     "\n",
-    " max_device_memory=\"2GB\" : 设置设备可用的最大内存为2GB。\n",
+    " runtime.set_memory(max_size=\"2GB\") : 设置设备可用的最大内存为2GB。\n",
     "\n",
-    " mode=ms.GRAPH_MODE : 表示在GRAPH_MODE模式中运行。\n",
+    " mode : 默认在Pynative模式下运行\n",
     "\n",
-    " device_target=\"Ascend\" : 表示待运行的目标设备为Ascend。\n",
+    " ms.set_device(\"Ascend\") : 表示待运行的目标设备为Ascend。\n",
     "\n",
-    " jit_config={\"jit_level\":\"O2\"} : 编译优化级别开启极致性能优化，使用下沉的执行方式。\n",
+    " jit_config={\"jit_level\":\"O1\"} : 使能常用优化和自动算子融合优化，使用逐算子执行的执行方式。\n",
     "\n",
     " ascend_config={\"precision_mode\":\"allow_mix_precision\"} : 自动混合精度，自动将部分算子的精度降低到float16或bfloat16。"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b5c7d9ee",
+   "execution_count": 1,
+   "id": "9d62bfbf-2beb-4d00-b3a6-74d3da59e78d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/miniconda3/lib/python3.9/site-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
+      "  setattr(self, word, getattr(machar, word).flat[0])\n",
+      "/usr/local/miniconda3/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
+      "  return self._float_to_str(self.smallest_subnormal)\n",
+      "/usr/local/miniconda3/lib/python3.9/site-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
+      "  setattr(self, word, getattr(machar, word).flat[0])\n",
+      "/usr/local/miniconda3/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
+      "  return self._float_to_str(self.smallest_subnormal)\n",
+      "[WARNING] ME(41309:255085693984800,MainProcess):2025-07-25-00:45:43.646.152 [mindspore/context.py:1402] For 'context.set_context', the parameter 'ascend_config' will be deprecated and removed in a future version. Please use the api mindspore.device_context.ascend.op_precision.precision_mode(),\n",
+      "                                                       mindspore.device_context.ascend.op_precision.op_precision_mode(),\n",
+      "                                                       mindspore.device_context.ascend.op_precision.matmul_allow_hf32(),\n",
+      "                                                       mindspore.device_context.ascend.op_precision.conv_allow_hf32(),\n",
+      "                                                       mindspore.device_context.ascend.op_tuning.op_compile() instead.\n"
+     ]
+    }
+   ],
    "source": [
     "import mindspore as ms\n",
-    "ms.set_context(max_device_memory=\"2GB\", mode=ms.GRAPH_MODE, device_target=\"Ascend\", jit_config={\"jit_level\":\"O2\"}, ascend_config={\"precision_mode\":\"allow_mix_precision\"})"
+    "ms.runtime.set_memory(max_size=\"2GB\")\n",
+    "\n",
+    "ms.set_device(\"Ascend\")\n",
+    "\n",
+    "ms.set_context(jit_config={\"jit_level\":\"O1\"}, ascend_config={\"precision_mode\":\"allow_mix_precision\"})\n"
    ]
   },
   {
@@ -109,7 +133,7 @@
      "text": [
       "Downloading data from https://mindspore-website.obs.cn-north-4.myhuaweicloud.com/notebook/datasets/ssd_datasets.zip (16.0 MB)\n",
       "\n",
-      "file_sizes: 100%|██████████████████████████| 16.8M/16.8M [00:00<00:00, 29.0MB/s]\n",
+      "file_sizes: 100%|██████████████████████████| 16.8M/16.8M [00:01<00:00, 10.8MB/s]\n",
       "Extracting zip file...\n",
       "Successfully downloaded / unzipped to ./\n"
      ]
@@ -182,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "5a635efe",
    "metadata": {},
    "outputs": [],
@@ -369,28 +393,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "727258ad",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[WARNING] ME(46927:281473569476624,MainProcess):2024-09-06-10:17:58.220.581 [mindspore/run_check/_check_version.py:357] MindSpore version 2.2.14 and Ascend AI software package (Ascend Data Center Solution)version 7.0 does not match, the version of software package expect one of ['7.1']. Please refer to the match info on: https://www.mindspore.cn/install\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
-      "  setattr(self, word, getattr(machar, word).flat[0])\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
-      "  setattr(self, word, getattr(machar, word).flat[0])\n",
-      "[WARNING] ME(46927:281473569476624,MainProcess):2024-09-06-10:18:00.386.763 [mindspore/run_check/_check_version.py:375] MindSpore version 2.2.14 and \"te\" wheel package version 7.0 does not match. For details, refer to the installation guidelines: https://www.mindspore.cn/install\n",
-      "[WARNING] ME(46927:281473569476624,MainProcess):2024-09-06-10:18:00.389.195 [mindspore/run_check/_check_version.py:382] MindSpore version 2.2.14 and \"hccl\" wheel package version 7.0 does not match. For details, refer to the installation guidelines: https://www.mindspore.cn/install\n",
-      "[WARNING] ME(46927:281473569476624,MainProcess):2024-09-06-10:18:00.389.966 [mindspore/run_check/_check_version.py:396] Please pay attention to the above warning, countdown: 3\n",
-      "[WARNING] ME(46927:281473569476624,MainProcess):2024-09-06-10:18:01.391.856 [mindspore/run_check/_check_version.py:396] Please pay attention to the above warning, countdown: 2\n",
-      "[WARNING] ME(46927:281473569476624,MainProcess):2024-09-06-10:18:02.393.126 [mindspore/run_check/_check_version.py:396] Please pay attention to the above warning, countdown: 1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "import mindspore as ms\n",
     "from mindspore import Tensor\n",
     "from mindspore.dataset import MindDataset\n",
     "from mindspore.dataset.vision import Decode, HWC2CHW, Normalize, RandomColorAdjust\n",
@@ -496,7 +504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "e6e8eff5",
    "metadata": {},
    "outputs": [],
@@ -556,13 +564,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "a0924735",
    "metadata": {},
    "outputs": [],
    "source": [
     "import mindspore.nn as nn\n",
-    "import mindspore.ops as ops\n",
+    "import mindspore.mint as mint\n",
     "\n",
     "def _last_conv2d(in_channel, out_channel, kernel_size=3, stride=1, pad_mod='same', pad=0):\n",
     "    in_channels = in_channel\n",
@@ -584,12 +592,12 @@
     "\n",
     "    def construct(self, inputs):\n",
     "        output = ()\n",
-    "        batch_size = ops.shape(inputs[0])[0]\n",
+    "        batch_size = inputs[0].shape[0]\n",
     "        for x in inputs:\n",
-    "            x = ops.transpose(x, (0, 2, 3, 1))\n",
-    "            output += (ops.reshape(x, (batch_size, -1)),)\n",
-    "        res = ops.concat(output, axis=1)\n",
-    "        return ops.reshape(res, (batch_size, self.num_ssd_boxes, -1))\n",
+    "            x = mint.permute(x, (0, 2, 3, 1))\n",
+    "            output += (mint.reshape(x, (batch_size, -1)),)\n",
+    "        res = mint.cat(output, dim=1)\n",
+    "        return mint.reshape(res, (batch_size, self.num_ssd_boxes, -1))\n",
     "\n",
     "class MultiBox(nn.Cell):\n",
     "    \"\"\"\n",
@@ -683,7 +691,7 @@
     "        multi_feature = (block4, block7, block8, block9, block10, block11)\n",
     "        pred_loc, pred_label = self.multi_box(multi_feature)\n",
     "        if not self.training:\n",
-    "            pred_label = ops.sigmoid(pred_label)\n",
+    "            pred_label = mint.sigmoid(pred_label)\n",
     "        pred_loc = pred_loc.astype(ms.float32)\n",
     "        pred_label = pred_label.astype(ms.float32)\n",
     "        return pred_loc, pred_label"
@@ -714,7 +722,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "89b8984e",
    "metadata": {},
    "outputs": [],
@@ -873,13 +881,13 @@
     "        default_bbox_xy = self.default_boxes[..., :2]\n",
     "        default_bbox_wh = self.default_boxes[..., 2:]\n",
     "        pred_xy = pred_loc[..., :2] * self.prior_scaling_xy * default_bbox_wh + default_bbox_xy\n",
-    "        pred_wh = ops.exp(pred_loc[..., 2:] * self.prior_scaling_wh) * default_bbox_wh\n",
+    "        pred_wh = mint.exp(pred_loc[..., 2:] * self.prior_scaling_wh) * default_bbox_wh\n",
     "\n",
     "        pred_xy_0 = pred_xy - pred_wh / 2.0\n",
     "        pred_xy_1 = pred_xy + pred_wh / 2.0\n",
-    "        pred_xy = ops.concat((pred_xy_0, pred_xy_1), -1)\n",
-    "        pred_xy = ops.maximum(pred_xy, 0)\n",
-    "        pred_xy = ops.minimum(pred_xy, 1)\n",
+    "        pred_xy = mint.cat((pred_xy_0, pred_xy_1), -1)\n",
+    "        pred_xy = mint.maximum(pred_xy, 0)\n",
+    "        pred_xy = mint.minimum(pred_xy, 1)\n",
     "        return pred_xy, pred_label"
    ]
   },
@@ -921,7 +929,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "1cfc125d",
    "metadata": {},
    "outputs": [],
@@ -1024,7 +1032,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "97df2be7",
    "metadata": {
     "scrolled": true
@@ -1034,9 +1042,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Downloading data from https://clouddrive-kwe.huawei.com/kwe7/api/96515B6505BCC9A86E997B305585BEB00E355460745F91C8F2F53056/bbe2e192378b377da7a687a134e081b0/ssd-60_9.ckpt (92.6 MB)\n",
+      "Downloading data from https://cdn.modelers.cn/lfs/b7/1f/ebf4c1cb3f3e00734eb08b35b134620c616490cc6afb9c861a609963449d?response-content-disposition=attachment%3B+filename%3D%22ssd-60_9.ckpt%22&AWSAccessKeyId=HAZQA0Q6AQL2GHX4TKTL&Expires=1753461953&Signature=xzSJY5Pfgq1DqjIjaqACM6Y5jlA%3D (92.6 MB)\n",
       "\n",
-      "file_sizes: 100%|██████████████████████████| 97.1M/97.1M [00:08<00:00, 11.0MB/s]\n",
+      "file_sizes: 100%|██████████████████████████| 97.1M/97.1M [00:09<00:00, 10.8MB/s]\n",
       "Successfully downloaded file to ./ssd-60_9.ckpt\n",
       "Start Eval!\n",
       "Load Checkpoint!\n",
@@ -1054,38 +1062,30 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
-      "  setattr(self, word, getattr(machar, word).flat[0])\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
-      "  setattr(self, word, getattr(machar, word).flat[0])\n",
-      "[ERROR] CORE(46927,ffffac1f5010,python):2024-09-06-10:23:36.577.738 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_46927/1464347597.py]\n",
-      "[ERROR] CORE(46927,ffffac1f5010,python):2024-09-06-10:23:36.577.847 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_46927/1464347597.py]\n",
-      "[ERROR] CORE(46927,ffffac1f5010,python):2024-09-06-10:23:36.577.878 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_46927/1464347597.py]\n",
-      "[ERROR] CORE(46927,ffffac1f5010,python):2024-09-06-10:23:36.578.610 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_46927/1464347597.py]\n",
-      "[ERROR] CORE(46927,ffffac1f5010,python):2024-09-06-10:23:36.578.643 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_46927/130566329.py]\n",
-      "[ERROR] CORE(46927,ffffac1f5010,python):2024-09-06-10:23:36.579.780 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_46927/130566329.py]\n"
+      "[WARNING] DEVICE(41309,e7ffc42d6020,python):2025-07-25-00:46:09.228.284 [mindspore/ccsrc/plugin/res_manager/ascend/mem_manager/ascend_memory_adapter.cc:123] Initialize] Free memory size is less than half of total memory size.Device 0 Device MOC total size:7912181760 Device MOC free size:3840520192 may be other processes occupying this card, check as: ps -ef|grep python\n",
+      "[WARNING] DEVICE(41309,e7ffc42d6020,python):2025-07-25-00:46:10.637.849 [mindspore/ccsrc/plugin/res_manager/ascend/mem_manager/abstract_ascend_memory_pool_support.cc:48] SetMemPoolBlockSize] Memory pool block size 2147483648 is bigger than currently available maximum memory 1073741824, and the actual effective value will be 1073741824\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loading and preparing results...\n",
-      "DONE (t=1.74s)\n",
+      "..Loading and preparing results...\n",
+      "DONE (t=2.96s)\n",
       "creating index...\n",
       "index created!\n",
       "Running per image evaluation...\n",
       "Evaluate annotation type *bbox*\n",
-      "DONE (t=1.42s).\n",
+      "DONE (t=3.37s).\n",
       "Accumulating evaluation results...\n",
-      "DONE (t=0.42s).\n",
-      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.006\n",
-      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.013\n",
+      "DONE (t=1.19s).\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.008\n",
+      " Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.015\n",
       " Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.000\n",
       " Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.000\n",
       " Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.009\n",
-      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.022\n",
-      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.023\n",
+      " Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.025\n",
+      " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.021\n",
       " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.042\n",
       " Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.072\n",
       " Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.000\n",
@@ -1094,7 +1094,7 @@
       "\n",
       "========================================\n",
       "\n",
-      "mAP: 0.005994237564895284\n"
+      "mAP: 0.007608299401667268\n"
      ]
     }
    ],
@@ -1135,9 +1135,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "MindSpore",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "mindspore"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1149,7 +1149,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,

--- a/Online/inference/README.md
+++ b/Online/inference/README.md
@@ -11,11 +11,11 @@
 
 | 模型名 | 支持CANN版本 | 支持Mindspore版本 | 支持的香橙派开发板型号 |
 | :----- |:----- |:----- |:-----|
-| [ResNet50](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/02-ResNet50) | 8.0.RC3.alpha002  | 2.4.10| 8T16G |
+| [ResNet50](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/02-ResNet50) | 8.1.RC1  | 2.6.0| 8T8G |
 |[ViT](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/03-ViT)| 8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[FCN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/04-FCN)| 8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[ShuffleNet](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/05-ShuffleNet)| 8.0.RC3.alpha002  | 2.4.10| 8T16G |
-|[SSD](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/06-SSD)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
+|[SSD](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/06-SSD)|8.1.RC1  | 2.6.0| 8T8G |
 |[RNN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/07-RNN)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[LSTM+CRF](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/08-LSTM%2BCRF)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[GAN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/09-GAN)|8.0.RC3.alpha002  | 2.4.10| 8T16G |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 |[ViT](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/03-ViT)| 推理 | 8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[FCN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/04-FCN)| 推理 | 8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[ShuffleNet](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/05-ShuffleNet)| 推理 | 8.0.RC3.alpha002  | 2.4.10| 8T16G |
-|[SSD](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/06-SSD)| 推理 | 8.0.RC3.alpha002  | 2.4.10| 8T16G |
+|[SSD](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/06-SSD)| 推理 | 8.1.RC1  | 2.6.0| 8T8G |
 |[RNN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/07-RNN)| 推理 | 8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[LSTM+CRF](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/08-LSTM%2BCRF)| 推理 | 8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[GAN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/09-GAN)| 推理 | 8.0.RC3.alpha002  | 2.4.10| 8T16G |


### PR DESCRIPTION
任务
任务编号：#ICJ92K
任务链接：[【开源实习】香橙派github仓中的在线推理案例06-SSD基于PyNative模式改写成以mint接口实现](https://gitee.com/mindspore/community/issues/ICJ92K)
版本信息:
Python 3.9 + MindSpore 2.6.0 + CANN 8.1.RC1
OrangePi AiPro 8G 8T

实现内容：
香橙派github仓中在线推理案例 06-SSD 基于MindSpore2.6.0的PyNative模式下可以在香橙派开发板正常流畅运行。

**修改为mint接口**
<img width="1760" height="267" alt="a8af487ca065d591f9fd39c1ff5645c" src="https://github.com/user-attachments/assets/1600b5de-78ff-4464-94c2-a4bda3352c66" />
<img width="1786" height="75" alt="97f5481dfd4f9eee8e6d6b81a6cbdd5" src="https://github.com/user-attachments/assets/f4ace3d7-0660-4979-af3d-bd6267a5742a" />
<img width="1788" height="218" alt="b35fc04ccb5de46ee7fde36c1cdcbf3" src="https://github.com/user-attachments/assets/7925f7ef-ff4d-4103-87f2-372fce5ec2c4" />

**推理正常**
<img width="1898" height="713" alt="47d3854b96f0503dfd6d77a133e7f84" src="https://github.com/user-attachments/assets/4259ed3a-d29b-4fa5-b6db-8833444401a9" />
