### PR TITLE
【开源实习】香橙派github仓中的在线推理案例08-LSTM+CRF基于PyNative模式改写成以mint接口实现

### DIFF
--- a/Online/README.md
+++ b/Online/README.md
@@ -36,7 +36,7 @@
 |[ShuffleNet](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/05-ShuffleNet)| 8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[SSD](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/06-SSD)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[RNN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/07-RNN)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
-|[LSTM+CRF](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/08-LSTM%2BCRF)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
+|[LSTM+CRF](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/08-LSTM%2BCRF)|8.1.RC1  | 2.6.0| 8T8G |
 |[GAN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/09-GAN)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[DCGAN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/10-DCGAN)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[Pix2Pix](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/11-Pix2Pix)|8.0.RC3.alpha002  | 2.4.10| 8T16G |

--- a/Online/inference/08-LSTM+CRF/mindspore_sequence_labeling.ipynb
+++ b/Online/inference/08-LSTM+CRF/mindspore_sequence_labeling.ipynb
@@ -35,26 +35,47 @@
     "\n",
     "由于资源限制，需开启性能优化模式，具体设置如下参数：\n",
     "\n",
-    " max_device_memory=\"2GB\" : 设置设备可用的最大内存为2GB。\n",
+    " mode=mindspore.GRAPH_MODE : 表示在GRAPH_MODE模式中运行\n",
     "\n",
-    " mode=mindspore.GRAPH_MODE : 表示在GRAPH_MODE模式中运行。\n",
+    " jit_config={\"jit_level\":\"O2\"} : 编译优化级别开启极致性能优化，使用下沉的执行方式\n",
     "\n",
-    " device_target=\"Ascend\" : 表示待运行的目标设备为Ascend。\n",
+    " set_device(\"Ascend\") : 表示待运行的目标设备为Ascend\n",
     "\n",
-    " jit_config={\"jit_level\":\"O2\"} : 编译优化级别开启极致性能优化，使用下沉的执行方式。\n",
+    " device_context.ascend.op_precision.precision_mode=(\"allow_mix_precision\") : 自动混合精度，自动将部分算子的精度降低到float16或bfloat16\n",
     "\n",
-    " ascend_config={\"precision_mode\":\"allow_mix_precision\"} : 自动混合精度，自动将部分算子的精度降低到float16或bfloat16。"
+    " runtime.set_memory(max_size=\"2GB\") : 设置设备可用的最大内存为2GB"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "f01741d9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/miniconda3/lib/python3.9/site-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
+      "  setattr(self, word, getattr(machar, word).flat[0])\n",
+      "/usr/local/miniconda3/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
+      "  return self._float_to_str(self.smallest_subnormal)\n",
+      "/usr/local/miniconda3/lib/python3.9/site-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
+      "  setattr(self, word, getattr(machar, word).flat[0])\n",
+      "/usr/local/miniconda3/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
+      "  return self._float_to_str(self.smallest_subnormal)\n"
+     ]
+    }
+   ],
    "source": [
-    "import mindspore\n",
-    "mindspore.set_context(max_device_memory=\"2GB\", mode=mindspore.GRAPH_MODE, device_target=\"Ascend\",  jit_config={\"jit_level\":\"O2\"}, ascend_config={\"precision_mode\":\"allow_mix_precision\"})"
+    "import mindspore \n",
+    "mindspore.set_context(mode=mindspore.GRAPH_MODE, jit_config={\"jit_level\":\"O2\"})\n",
+    "\n",
+    "mindspore.set_device(\"Ascend\")\n",
+    "\n",
+    "mindspore.device_context.ascend.op_precision.precision_mode=(\"allow_mix_precision\")\n",
+    "\n",
+    "mindspore.runtime.set_memory(max_size=\"2GB\")"
    ]
   },
   {
@@ -124,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "d09936ad-6b20-4423-9f57-8e14917e61d4",
    "metadata": {},
    "outputs": [],
@@ -142,7 +163,7 @@
     "    score = start_trans[tags[0]]\n",
     "    # score += 第一次发射概率\n",
     "    # shape: (batch_size,)\n",
-    "    score += emissions[0, mnp.arange(batch_size), tags[0]]\n",
+    "    score += emissions[0, ms.mint.arange(batch_size), tags[0]]\n",
     "\n",
     "    for i in range(1, seq_length):\n",
     "        # 标签由i-1转移至i的转移概率（当mask == 1时有效）\n",
@@ -151,11 +172,11 @@
     "\n",
     "        # 预测tags[i]的发射概率（当mask == 1时有效）\n",
     "        # shape: (batch_size,)\n",
-    "        score += emissions[i, mnp.arange(batch_size), tags[i]] * mask[i]\n",
+    "        score += emissions[i, ms.mint.arange(batch_size), tags[i]] * mask[i]\n",
     "\n",
     "    # 结束转移\n",
     "    # shape: (batch_size,)\n",
-    "    last_tags = tags[seq_ends, mnp.arange(batch_size)]\n",
+    "    last_tags = tags[seq_ends, ms.mint.arange(batch_size)]\n",
     "    # score += 结束转移概率\n",
     "    # shape: (batch_size,)\n",
     "    score += end_trans[last_tags]\n",
@@ -185,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "d9a0ef6a-1c3a-400e-9053-e0659e8f9e7e",
    "metadata": {},
    "outputs": [],
@@ -217,7 +238,7 @@
     "\n",
     "        # 对score_i做log_sum_exp运算，用于下一个Token的score计算\n",
     "        # shape: (batch_size, num_tags)\n",
-    "        next_score = ops.logsumexp(next_score, axis=1)\n",
+    "        next_score = ms.mint.logsumexp(next_score, dim=1)\n",
     "\n",
     "        # 当mask == 1时，score才会变化\n",
     "        # shape: (batch_size, num_tags)\n",
@@ -228,7 +249,7 @@
     "    score += end_trans\n",
     "    # 对所有可能的路径得分求log_sum_exp\n",
     "    # shape: (batch_size,)\n",
-    "    return ops.logsumexp(score, axis=1)"
+    "    return ms.mint.logsumexp(score, dim=1)"
    ]
   },
   {
@@ -251,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "7c286935-74eb-413a-8e47-b8fb5264e6b6",
    "metadata": {},
    "outputs": [],
@@ -321,27 +342,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "120a39c7-c89d-4cd3-8a75-da27d2853f0e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[WARNING] ME(97316:281472950050832,MainProcess):2024-09-06-10:50:02.452.307 [mindspore/run_check/_check_version.py:357] MindSpore version 2.2.14 and Ascend AI software package (Ascend Data Center Solution)version 7.0 does not match, the version of software package expect one of ['7.1']. Please refer to the match info on: https://www.mindspore.cn/install\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
-      "  setattr(self, word, getattr(machar, word).flat[0])\n",
-      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
-      "  setattr(self, word, getattr(machar, word).flat[0])\n",
-      "[WARNING] ME(97316:281472950050832,MainProcess):2024-09-06-10:50:04.855.681 [mindspore/run_check/_check_version.py:375] MindSpore version 2.2.14 and \"te\" wheel package version 7.0 does not match. For details, refer to the installation guidelines: https://www.mindspore.cn/install\n",
-      "[WARNING] ME(97316:281472950050832,MainProcess):2024-09-06-10:50:04.861.443 [mindspore/run_check/_check_version.py:382] MindSpore version 2.2.14 and \"hccl\" wheel package version 7.0 does not match. For details, refer to the installation guidelines: https://www.mindspore.cn/install\n",
-      "[WARNING] ME(97316:281472950050832,MainProcess):2024-09-06-10:50:04.862.319 [mindspore/run_check/_check_version.py:396] Please pay attention to the above warning, countdown: 3\n",
-      "[WARNING] ME(97316:281472950050832,MainProcess):2024-09-06-10:50:05.864.215 [mindspore/run_check/_check_version.py:396] Please pay attention to the above warning, countdown: 2\n",
-      "[WARNING] ME(97316:281472950050832,MainProcess):2024-09-06-10:50:06.866.175 [mindspore/run_check/_check_version.py:396] Please pay attention to the above warning, countdown: 1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import mindspore as ms\n",
     "import mindspore.nn as nn\n",
@@ -351,7 +355,7 @@
     "\n",
     "def sequence_mask(seq_length, max_length, batch_first=False):\n",
     "    \"\"\"根据序列实际长度和最大长度生成mask矩阵\"\"\"\n",
-    "    range_vector = mnp.arange(0, max_length, 1, seq_length.dtype)\n",
+    "    range_vector = ms.mint.arange(0, max_length, dtype=seq_length.dtype)\n",
     "    result = range_vector < seq_length.view(seq_length.shape + (1,))\n",
     "    if batch_first:\n",
     "        return result.astype(ms.int64)\n",
@@ -385,7 +389,7 @@
     "            max_length, batch_size = tags.shape\n",
     "\n",
     "        if seq_length is None:\n",
-    "            seq_length = mnp.full((batch_size,), max_length, ms.int64)\n",
+    "            seq_length = ms.mint.full((batch_size,), max_length, ms.int64)\n",
     "\n",
     "        mask = sequence_mask(seq_length, max_length)\n",
     "\n",
@@ -412,7 +416,7 @@
     "            batch_size, max_length = emissions.shape[:2]\n",
     "\n",
     "        if seq_length is None:\n",
-    "            seq_length = mnp.full((batch_size,), max_length, ms.int64)\n",
+    "            seq_length = ms.mint.full((batch_size,), max_length, ms.int64)\n",
     "\n",
     "        mask = sequence_mask(seq_length, max_length)\n",
     "\n",
@@ -437,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "c07555e3-f2a2-4c25-beff-5a78491ab2d1",
    "metadata": {},
    "outputs": [],
@@ -445,9 +449,9 @@
     "class BiLSTM_CRF(nn.Cell):\n",
     "    def __init__(self, vocab_size, embedding_dim, hidden_dim, num_tags, padding_idx=0):\n",
     "        super().__init__()\n",
-    "        self.embedding = nn.Embedding(vocab_size, embedding_dim, padding_idx=padding_idx)\n",
+    "        self.embedding = ms.mint.nn.Embedding(vocab_size, embedding_dim, padding_idx=padding_idx)\n",
     "        self.lstm = nn.LSTM(embedding_dim, hidden_dim // 2, bidirectional=True, batch_first=True)\n",
-    "        self.hidden2tag = nn.Dense(hidden_dim, num_tags, 'he_uniform')\n",
+    "        self.hidden2tag = ms.mint.nn.Linear(hidden_dim, num_tags)\n",
     "        self.crf = CRF(num_tags, batch_first=True)\n",
     "\n",
     "    def construct(self, inputs, seq_length, tags=None):\n",
@@ -469,7 +473,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "fa53f535-34bc-49a3-b769-e85d3a184cc0",
    "metadata": {},
    "outputs": [],
@@ -497,7 +501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "5c255358-938b-4e88-a810-2fe4e616a044",
    "metadata": {},
    "outputs": [
@@ -507,7 +511,7 @@
        "21"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -526,10 +530,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "e6d3f2bb-0ea7-457c-8a74-a8e0ea78a109",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[WARNING] DEVICE(4153,e7ffe771d020,python):2025-07-25-15:14:14.782.530 [mindspore/ccsrc/plugin/res_manager/ascend/mem_manager/abstract_ascend_memory_pool_support.cc:48] SetMemPoolBlockSize] Memory pool block size 2147483648 is bigger than currently available maximum memory 1073741824, and the actual effective value will be 1073741824\n"
+     ]
+    }
+   ],
    "source": [
     "model = BiLSTM_CRF(len(word_to_idx), embedding_dim, hidden_dim, len(tag_to_idx))"
    ]
@@ -544,7 +556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "7899b6e6-95a4-4ffe-ba49-b27cebe8b306",
    "metadata": {},
    "outputs": [],
@@ -569,7 +581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "0e984dcb-6f89-4520-940f-620cdb997529",
    "metadata": {},
    "outputs": [
@@ -579,7 +591,7 @@
        "((2, 11), (2, 11), (2,))"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -599,20 +611,141 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "65304086-de03-4edc-b3a2-3ca5e43c4795",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading data from https://cdn.modelers.cn/lfs/b8/d8/c8dd957c842f8c2c4c07ee2e77dee1fca7abe0e8305fdc6b301453aae00b?response-content-disposition=attachment%3B+filename%3D%22lstm-crf.ckpt%22&AWSAccessKeyId=HAZQA0Q6AQL2GHX4TKTL&Expires=1753514196&Signature=n7Ei5ShhK550IsSq07TDg0PrLQk%3D (19 kB)\n",
+      "\n",
+      "file_sizes: 100%|██████████████████████████| 19.8k/19.8k [00:00<00:00, 3.11MB/s]\n",
+      "Successfully downloaded file to ./lstm-crf.ckpt\n",
+      "Renaming parameter key for compatibility...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[ERROR] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.419.212 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_4153/1975012904.py]\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.419.849 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[ERROR] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.419.956 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_4153/2754491349.py]\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.419.981 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[ERROR] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.420.063 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_4153/2754491349.py]\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.420.084 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.130 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.205 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.235 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.263 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.288 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.313 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.337 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.361 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.515.795 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.515.857 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.515.884 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.515.910 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.515.935 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.515.959 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.515.983 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.516.007 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.779 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.831 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.857 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.887 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.912 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.936 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.960 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.984 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.521.803 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.521.854 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.521.881 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.521.906 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.521.931 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.521.955 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.521.979 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.522.003 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.446 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.497 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.523 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.549 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.609 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.639 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.664 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.688 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.097 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.145 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.176 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.202 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.226 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.250 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.274 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.298 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.654 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.702 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.728 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.753 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.777 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.801 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.825 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.849 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.216 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.265 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.291 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.317 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.341 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.365 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.389 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.413 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.535.814 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.535.868 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.535.894 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.535.919 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.535.943 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.535.966 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.535.990 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.536.014 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.426 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.476 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.502 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.527 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.551 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.575 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.599 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.623 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Tensor(shape=[2, 3], dtype=Float32, value=\n",
+       "[[ 3.28325005e+01,  3.76421967e+01,  3.22423592e+01],\n",
+       " [ 2.89638519e+01,  2.69470749e+01,  3.40986862e+01]])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from mindspore import load_param_into_net, load_checkpoint\n",
     "from download import download\n",
     "\n",
-    "# download ckpt\n",
     "lstm_crf_url = \"https://modelers.cn/coderepo/web/v1/file/MindSpore-Lab/cluoud_obs/main/media/examples/mindspore-courses/orange-pi-online-infer/08-LSTM%2BCRF/lstm-crf.ckpt\"\n",
     "path = \"./lstm-crf.ckpt\"\n",
     "ckpt_path = download(lstm_crf_url, path, replace=True)\n",
     "\n",
     "load_checkpoint=load_checkpoint(ckpt_path)\n",
+    "\n",
+    "#由于lstm-crf.ckpt是通过nn.Embedding训练的，将其迁移到mint.nn.Embedding需要修改参数embedding_table为weight\n",
+    "if 'embedding.embedding_table' in load_checkpoint:\n",
+    "    print(\"Renaming parameter key for compatibility...\")\n",
+    "    load_checkpoint['embedding.weight'] = load_checkpoint.pop('embedding.embedding_table')\n",
+    "\n",
     "load_param_into_net(model, load_checkpoint)\n",
     "score, history = model(data, seq_length)\n",
     "score"
@@ -628,17 +761,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 13,
    "id": "ed5ff78a-099c-41f8-ac1e-8f9fbfab7659",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "[[0, 1, 1, 1, 2, 2, 2, 2, 2, 0, 1], [0, 1, 2, 2, 2, 2, 2, 2, 2]]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -658,7 +798,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 14,
    "id": "df505983-9c1f-4e09-8a67-1cd78ce69fd0",
    "metadata": {},
    "outputs": [],
@@ -674,7 +814,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 15,
    "id": "e30d43c7-7c09-445e-94a4-33fccfaeaf11",
    "metadata": {},
    "outputs": [
@@ -685,7 +825,7 @@
        " ['B', 'I', 'O', 'O', 'O', 'O', 'O', 'O', 'O']]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -697,9 +837,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "MindSpore",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "mindspore"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -711,7 +851,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.9.2"
   },
   "vscode": {
    "interpreter": {

--- a/Online/inference/08-LSTM+CRF/mindspore_sequence_labeling.ipynb
+++ b/Online/inference/08-LSTM+CRF/mindspore_sequence_labeling.ipynb
@@ -531,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "e6d3f2bb-0ea7-457c-8a74-a8e0ea78a109",
    "metadata": {},
    "outputs": [],
@@ -549,7 +549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "7899b6e6-95a4-4ffe-ba49-b27cebe8b306",
    "metadata": {},
    "outputs": [],
@@ -574,10 +574,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "0e984dcb-6f89-4520-940f-620cdb997529",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((2, 11), (2, 11), (2,))"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "data, label, seq_length = prepare_sequence(training_data, word_to_idx, tag_to_idx)\n",
     "data.shape, label.shape, seq_length.shape"
@@ -593,10 +604,126 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "65304086-de03-4edc-b3a2-3ca5e43c4795",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading data from https://cdn.modelers.cn/lfs/b8/d8/c8dd957c842f8c2c4c07ee2e77dee1fca7abe0e8305fdc6b301453aae00b?response-content-disposition=attachment%3B+filename%3D%22lstm-crf.ckpt%22&AWSAccessKeyId=HAZQA0Q6AQL2GHX4TKTL&Expires=1753624653&Signature=KPFQ7w1rvlmou3Tm7Jfe4cql0mw%3D (19 kB)\n",
+      "\n",
+      "file_sizes: 100%|██████████████████████████| 19.8k/19.8k [00:00<00:00, 3.78MB/s]\n",
+      "Successfully downloaded file to ./lstm-crf.ckpt\n",
+      "Renaming parameter key for compatibility...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[ERROR] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.741.864 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_9878/1975012904.py]\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.742.412 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[ERROR] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.742.524 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_9878/2754491349.py]\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.742.546 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[ERROR] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.742.628 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_9878/2754491349.py]\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.742.647 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.796.908 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.796.975 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.797.004 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.797.031 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.797.057 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.797.082 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.797.106 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.797.130 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.819.099 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.819.161 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.819.190 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.819.217 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.819.243 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.819.268 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.819.292 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.819.316 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.821.918 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.821.970 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.821.996 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.822.026 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.822.052 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.822.076 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.822.101 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.822.125 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.824.812 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.824.863 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.824.889 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.824.913 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.824.937 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.824.961 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.824.985 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.825.009 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.827.876 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.827.926 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.827.954 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.827.979 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.828.004 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.828.029 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.828.053 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.828.077 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.830.349 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.830.396 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.830.426 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.830.451 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.830.476 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.830.500 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.830.524 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.830.548 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.832.754 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.832.805 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.832.831 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.832.855 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.832.880 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.832.904 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.832.928 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.832.951 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.835.175 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.835.225 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.835.251 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.835.276 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.835.300 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.835.324 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.835.348 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.835.372 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.837.536 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.837.590 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.837.617 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.837.642 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.837.667 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.837.691 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.837.715 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.837.739 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.840.718 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.840.770 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/1975012904.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.840.796 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.840.821 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.840.846 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.840.870 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2783059926.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.840.894 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n",
+      "[WARNING] CORE(9878,e7ffea68c020,python):2025-07-26-21:57:52.840.918 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_9878/2754491349.py' may not exists.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Tensor(shape=[2, 3], dtype=Float32, value=\n",
+       "[[ 3.28325005e+01,  3.76421967e+01,  3.22423592e+01],\n",
+       " [ 2.89638519e+01,  2.69470749e+01,  3.40986862e+01]])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from mindspore import load_param_into_net, load_checkpoint\n",
     "from download import download\n",
@@ -627,10 +754,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "ed5ff78a-099c-41f8-ac1e-8f9fbfab7659",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[[0, 1, 1, 1, 2, 2, 2, 2, 2, 0, 1], [0, 1, 2, 2, 2, 2, 2, 2, 2]]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "predict = post_decode(score, history, seq_length)\n",
     "predict"
@@ -646,7 +791,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "df505983-9c1f-4e09-8a67-1cd78ce69fd0",
    "metadata": {},
    "outputs": [],
@@ -662,10 +807,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "e30d43c7-7c09-445e-94a4-33fccfaeaf11",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[['B', 'I', 'I', 'I', 'O', 'O', 'O', 'O', 'O', 'B', 'I'],\n",
+       " ['B', 'I', 'O', 'O', 'O', 'O', 'O', 'O', 'O']]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sequence_to_tag(predict, idx_to_tag)"
    ]

--- a/Online/inference/08-LSTM+CRF/mindspore_sequence_labeling.ipynb
+++ b/Online/inference/08-LSTM+CRF/mindspore_sequence_labeling.ipynb
@@ -31,19 +31,26 @@
    "id": "3b5517e9",
    "metadata": {},
    "source": [
-    "## 设置运行环境\n",
+    "## 环境准备\n",
     "\n",
-    "由于资源限制，需开启性能优化模式，具体设置如下参数：\n",
+    "开发者拿到香橙派开发板后，首先需要进行硬件资源确认，镜像烧录及CANN和MindSpore版本的升级，才可运行该案例，具体如下：\n",
     "\n",
-    " mode=mindspore.GRAPH_MODE : 表示在GRAPH_MODE模式中运行\n",
+    "- 硬件： 香橙派AIpro 8G 8T开发板\n",
+    "- 镜像： 香橙派官网ubuntu镜像\n",
+    "- CANN：8.1.RC1\n",
+    "- MindSpore： 2.6.0\n",
     "\n",
-    " jit_config={\"jit_level\":\"O2\"} : 编译优化级别开启极致性能优化，使用下沉的执行方式\n",
+    "### 镜像烧录\n",
     "\n",
-    " set_device(\"Ascend\") : 表示待运行的目标设备为Ascend\n",
+    "运行该案例需要烧录香橙派官网ubuntu镜像，烧录流程参考[昇思MindSpore官网--香橙派开发专区--环境搭建指南--镜像烧录](https://www.mindspore.cn/tutorials/zh-CN/r2.6.0/orange_pi/environment_setup.html#1-%E9%95%9C%E5%83%8F%E7%83%A7%E5%BD%95%E4%BB%A5windows%E7%B3%BB%E7%BB%9F%E4%B8%BA%E4%BE%8B)章节。\n",
     "\n",
-    " device_context.ascend.op_precision.precision_mode=(\"allow_mix_precision\") : 自动混合精度，自动将部分算子的精度降低到float16或bfloat16\n",
+    "### CANN升级\n",
     "\n",
-    " runtime.set_memory(max_size=\"2GB\") : 设置设备可用的最大内存为2GB"
+    "CANN升级参考[昇思MindSpore官网--香橙派开发专区--环境搭建指南--CANN升级](https://www.mindspore.cn/tutorials/zh-CN/r2.6.0/orange_pi/environment_setup.html#3-cann%E5%8D%87%E7%BA%A7)章节。\n",
+    "\n",
+    "### MindSpore升级\n",
+    "\n",
+    "MindSpore升级参考[昇思MindSpore官网--香橙派开发专区--环境搭建指南--MindSpore升级](https://www.mindspore.cn/tutorials/zh-CN/r2.6.0/orange_pi/environment_setup.html#4-mindspore%E5%8D%87%E7%BA%A7)章节。"
    ]
   },
   {
@@ -69,13 +76,7 @@
    ],
    "source": [
     "import mindspore \n",
-    "mindspore.set_context(mode=mindspore.GRAPH_MODE, jit_config={\"jit_level\":\"O2\"})\n",
-    "\n",
-    "mindspore.set_device(\"Ascend\")\n",
-    "\n",
-    "mindspore.device_context.ascend.op_precision.precision_mode=(\"allow_mix_precision\")\n",
-    "\n",
-    "mindspore.runtime.set_memory(max_size=\"2GB\")"
+    "mindspore.set_context(mode=mindspore.GRAPH_MODE, jit_config={\"jit_level\":\"O2\"}) #在GRAPH_MODE模式中运行,且编译优化级别开启极致性能优化，使用下沉的执行方式"
    ]
   },
   {
@@ -530,18 +531,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "e6d3f2bb-0ea7-457c-8a74-a8e0ea78a109",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[WARNING] DEVICE(4153,e7ffe771d020,python):2025-07-25-15:14:14.782.530 [mindspore/ccsrc/plugin/res_manager/ascend/mem_manager/abstract_ascend_memory_pool_support.cc:48] SetMemPoolBlockSize] Memory pool block size 2147483648 is bigger than currently available maximum memory 1073741824, and the actual effective value will be 1073741824\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "model = BiLSTM_CRF(len(word_to_idx), embedding_dim, hidden_dim, len(tag_to_idx))"
    ]
@@ -556,7 +549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "7899b6e6-95a4-4ffe-ba49-b27cebe8b306",
    "metadata": {},
    "outputs": [],
@@ -581,21 +574,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "0e984dcb-6f89-4520-940f-620cdb997529",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "((2, 11), (2, 11), (2,))"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "data, label, seq_length = prepare_sequence(training_data, word_to_idx, tag_to_idx)\n",
     "data.shape, label.shape, seq_length.shape"
@@ -611,126 +593,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "65304086-de03-4edc-b3a2-3ca5e43c4795",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading data from https://cdn.modelers.cn/lfs/b8/d8/c8dd957c842f8c2c4c07ee2e77dee1fca7abe0e8305fdc6b301453aae00b?response-content-disposition=attachment%3B+filename%3D%22lstm-crf.ckpt%22&AWSAccessKeyId=HAZQA0Q6AQL2GHX4TKTL&Expires=1753514196&Signature=n7Ei5ShhK550IsSq07TDg0PrLQk%3D (19 kB)\n",
-      "\n",
-      "file_sizes: 100%|██████████████████████████| 19.8k/19.8k [00:00<00:00, 3.11MB/s]\n",
-      "Successfully downloaded file to ./lstm-crf.ckpt\n",
-      "Renaming parameter key for compatibility...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[ERROR] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.419.212 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_4153/1975012904.py]\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.419.849 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[ERROR] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.419.956 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_4153/2754491349.py]\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.419.981 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[ERROR] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.420.063 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_4153/2754491349.py]\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.420.084 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.130 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.205 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.235 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.263 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.288 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.313 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.337 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.493.361 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.515.795 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.515.857 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.515.884 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.515.910 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.515.935 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.515.959 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.515.983 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.516.007 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.779 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.831 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.857 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.887 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.912 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.936 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.960 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.518.984 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.521.803 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.521.854 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.521.881 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.521.906 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.521.931 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.521.955 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.521.979 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.522.003 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.446 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.497 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.523 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.549 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.609 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.639 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.664 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.525.688 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.097 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.145 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.176 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.202 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.226 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.250 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.274 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.528.298 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.654 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.702 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.728 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.753 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.777 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.801 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.825 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.530.849 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.216 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.265 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.291 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.317 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.341 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.365 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.389 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.533.413 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.535.814 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.535.868 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.535.894 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.535.919 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.535.943 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.535.966 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.535.990 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.536.014 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.426 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.476 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/1975012904.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.502 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.527 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.551 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.575 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2783059926.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.599 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n",
-      "[WARNING] CORE(4153,e7ffe771d020,python):2025-07-25-15:17:17.538.623 [mindspore/core/utils/info.cc:125] ToString] The file '/tmp/ipykernel_4153/2754491349.py' may not exists.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Tensor(shape=[2, 3], dtype=Float32, value=\n",
-       "[[ 3.28325005e+01,  3.76421967e+01,  3.22423592e+01],\n",
-       " [ 2.89638519e+01,  2.69470749e+01,  3.40986862e+01]])"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from mindspore import load_param_into_net, load_checkpoint\n",
     "from download import download\n",
@@ -761,28 +627,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "ed5ff78a-099c-41f8-ac1e-8f9fbfab7659",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[[0, 1, 1, 1, 2, 2, 2, 2, 2, 0, 1], [0, 1, 2, 2, 2, 2, 2, 2, 2]]"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "predict = post_decode(score, history, seq_length)\n",
     "predict"
@@ -798,7 +646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "df505983-9c1f-4e09-8a67-1cd78ce69fd0",
    "metadata": {},
    "outputs": [],
@@ -814,22 +662,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "e30d43c7-7c09-445e-94a4-33fccfaeaf11",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[['B', 'I', 'I', 'I', 'O', 'O', 'O', 'O', 'O', 'B', 'I'],\n",
-       " ['B', 'I', 'O', 'O', 'O', 'O', 'O', 'O', 'O']]"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sequence_to_tag(predict, idx_to_tag)"
    ]

--- a/Online/inference/README.md
+++ b/Online/inference/README.md
@@ -17,7 +17,7 @@
 |[ShuffleNet](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/05-ShuffleNet)| 8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[SSD](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/06-SSD)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[RNN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/07-RNN)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
-|[LSTM+CRF](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/08-LSTM%2BCRF)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
+|[LSTM+CRF](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/08-LSTM%2BCRF)|8.1.RC1  | 2.6.0| 8T8G |
 |[GAN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/09-GAN)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[DCGAN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/10-DCGAN)|8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[Pix2Pix](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/11-Pix2Pix)|8.0.RC3.alpha002  | 2.4.10| 8T16G |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 |[ShuffleNet](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/05-ShuffleNet)| 推理 | 8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[SSD](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/06-SSD)| 推理 | 8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[RNN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/07-RNN)| 推理 | 8.0.RC3.alpha002  | 2.4.10| 8T16G |
-|[LSTM+CRF](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/08-LSTM%2BCRF)| 推理 | 8.0.RC3.alpha002  | 2.4.10| 8T16G |
+|[LSTM+CRF](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/08-LSTM%2BCRF)| 推理 | 8.1.RC1  | 2.6.0| 8T8G |
 |[GAN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/09-GAN)| 推理 | 8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[DCGAN](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/10-DCGAN)|  推理 |8.0.RC3.alpha002  | 2.4.10| 8T16G |
 |[Pix2Pix](https://github.com/mindspore-courses/orange-pi-mindspore/tree/master/Online/inference/11-Pix2Pix)|  推理 | 8.0.RC3.alpha002  | 2.4.10| 8T16G |


### PR DESCRIPTION
任务
任务编号：#ICJ93S
任务链接：[【开源实习】香橙派github仓中的在线推理案例08-LSTM+CRF基于PyNative模式改写成以mint接口实现](https://gitee.com/mindspore/community/issues/ICJ93S)
版本信息:
Python 3.9 + MindSpore 2.6.0 + CANN 8.1.RC1
OrangePi AiPro 8G 8T

实现内容：
香橙派github仓中在线推理案例 06-SSD MindSpore2.6.0 在GRAPH_MODE下可以在香橙派开发板正常流畅运行。

原代码在Pynative模式下即运行报错，但经过测试，在Ascend 910B上可以正常推理。
疑似为 DynamicRNN算子 针对310B的TBE实现可能存在缺陷或未完全适配。

已将部分接口修改为mint接口。方便后续算子适配完成，代码修改为Pynative模式后，提升推理性能

<img width="1723" height="489" alt="23969f7ec44a3bf30788012ee981a3f" src="https://github.com/user-attachments/assets/1c3637f7-3e0b-4dd9-93e8-22a9626d5c5c" />

<img width="1784" height="472" alt="d9d111559e2cba4821912fad97b0b2e" src="https://github.com/user-attachments/assets/2fb86355-46a8-4263-8572-0d1da2835d3e" />

<img width="1767" height="47" alt="a13ceecc12f64980284261eaa90f761" src="https://github.com/user-attachments/assets/9b6681f7-701a-4181-b052-0ff3a075206a" />

<img width="1762" height="92" alt="de01943373b89668aa65d3708a76366" src="https://github.com/user-attachments/assets/10e91342-a5b7-4595-bdde-2e3177ed7cc0" />

<img width="1781" height="118" alt="7a82369434d2cd2036417d1b1a6244e" src="https://github.com/user-attachments/assets/009a3730-77ab-46d7-82c2-917ec6e9a67b" />


完成 `nn.Embedding` 参数名 到 `mint.nn.Embedding` 参数名的迁移
<img width="1776" height="171" alt="4c7ec9dba47aff372ce5e0b72f8f986" src="https://github.com/user-attachments/assets/7c9d3f70-4691-4a3a-8a44-5b575a41b876" />

推理正常
<img width="1849" height="864" alt="3b1a3e2d02322e03d2e54e4176ca1ca" src="https://github.com/user-attachments/assets/b677a601-92d0-4d91-a95c-5b59ba3b4624" />


