### PR TITLE
【开源实习】香橙派github仓中的在线推理案例07-RNN基于PyNative模式改写成以mint接口实现

### DIFF
--- a/Online/inference/07-RNN/mindspore_sentiment_analysis.ipynb
+++ b/Online/inference/07-RNN/mindspore_sentiment_analysis.ipynb
@@ -39,40 +39,22 @@
     "\n",
     "开发者拿到香橙派开发板后，首先需要进行硬件资源确认，镜像烧录及CANN和MindSpore版本的升级，才可运行该案例，具体如下：\n",
     "\n",
-    "- 硬件： 香橙派AIpro 16G 8-12T开发板\n",
+    "- 硬件： 香橙派AIpro 8G 8T开发板\n",
     "- 镜像： 香橙派官网ubuntu镜像\n",
-    "- CANN：8.0.RC3.alpha002\n",
-    "- MindSpore： 2.4.10\n",
+    "- CANN：8.1.RC1\n",
+    "- MindSpore： 2.6.0\n",
     "\n",
     "### 镜像烧录\n",
     "\n",
-    "运行该案例需要烧录香橙派官网ubuntu镜像，烧录流程参考[昇思MindSpore官网--香橙派开发专区--环境搭建指南--镜像烧录](https://www.mindspore.cn/docs/zh-CN/r2.4.10/orange_pi/environment_setup.html#1-%E9%95%9C%E5%83%8F%E7%83%A7%E5%BD%95%E4%BB%A5windows%E7%B3%BB%E7%BB%9F%E4%B8%BA%E4%BE%8B)章节。\n",
+    "运行该案例需要烧录香橙派官网ubuntu镜像，烧录流程参考[昇思MindSpore官网--香橙派开发专区--环境搭建指南--镜像烧录](https://www.mindspore.cn/tutorials/zh-CN/r2.6.0/orange_pi/environment_setup.html#1-%E9%95%9C%E5%83%8F%E7%83%A7%E5%BD%95%E4%BB%A5windows%E7%B3%BB%E7%BB%9F%E4%B8%BA%E4%BE%8B)章节。\n",
     "\n",
     "### CANN升级\n",
     "\n",
-    "CANN升级参考[昇思MindSpore官网--香橙派开发专区--环境搭建指南--CANN升级](https://www.mindspore.cn/docs/zh-CN/r2.4.10/orange_pi/environment_setup.html#3-cann%E5%8D%87%E7%BA%A7)章节。\n",
+    "CANN升级参考[昇思MindSpore官网--香橙派开发专区--环境搭建指南--CANN升级](https://www.mindspore.cn/tutorials/zh-CN/r2.6.0/orange_pi/environment_setup.html#3-cann%E5%8D%87%E7%BA%A7)章节。\n",
     "\n",
     "### MindSpore升级\n",
     "\n",
-    "MindSpore升级参考[昇思MindSpore官网--香橙派开发专区--环境搭建指南--MindSpore升级](https://www.mindspore.cn/docs/zh-CN/r2.4.10/orange_pi/environment_setup.html#4-mindspore%E5%8D%87%E7%BA%A7)章节。"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5ff6983a",
-   "metadata": {},
-   "source": [
-    "## 设置运行环境\n",
-    "\n",
-    " max_device_memory=\"2GB\" : 设置设备可用的最大内存为2GB。\n",
-    "\n",
-    " mode=mindspore.GRAPH_MODE : 表示在GRAPH_MODE模式中运行。\n",
-    "\n",
-    " device_target=\"Ascend\" : 表示待运行的目标设备为Ascend。\n",
-    "\n",
-    " jit_config={\"jit_level\":\"O2\"} : 编译优化级别开启极致性能优化，使用下沉的执行方式。\n",
-    "\n",
-    " scend_config={\"precision_mode\":\"allow_mix_precision\"} : 自动混合精度，自动将部分算子的精度降低到float16或bfloat16。"
+    "MindSpore升级参考[昇思MindSpore官网--香橙派开发专区--环境搭建指南--MindSpore升级](https://www.mindspore.cn/tutorials/zh-CN/r2.6.0/orange_pi/environment_setup.html#4-mindspore%E5%8D%87%E7%BA%A7)章节。"
    ]
   },
   {
@@ -87,20 +69,33 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
+      "/usr/local/miniconda3/envs/ms/lib/python3.10/site-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
       "  setattr(self, word, getattr(machar, word).flat[0])\n",
-      "/home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
+      "/usr/local/miniconda3/envs/ms/lib/python3.10/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
       "  return self._float_to_str(self.smallest_subnormal)\n",
-      "/home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
+      "/usr/local/miniconda3/envs/ms/lib/python3.10/site-packages/numpy/core/getlimits.py:549: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
       "  setattr(self, word, getattr(machar, word).flat[0])\n",
-      "/home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
+      "/usr/local/miniconda3/envs/ms/lib/python3.10/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
       "  return self._float_to_str(self.smallest_subnormal)\n"
      ]
     }
    ],
    "source": [
-    "import mindspore\n",
-    "mindspore.set_context(max_device_memory=\"2GB\", mode=mindspore.GRAPH_MODE, device_target=\"Ascend\",  jit_config={\"jit_level\":\"O2\"}, ascend_config={\"precision_mode\":\"allow_mix_precision\"})"
+    "import os, shutil, tempfile, zipfile, requests\n",
+    "from typing import IO, Dict, Any, List\n",
+    "import numpy as np\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "import mindspore as ms\n",
+    "import mindspore.dataset as ds\n",
+    "from mindspore import mint\n",
+    "from mindspore.mint import nn as mnn\n",
+    "from mindspore.mint.nn import functional as F\n",
+    "import mindspore.nn as nn\n",
+    "ms.set_device(\"Ascend\")                                \n",
+    "ms.set_context(mode=ms.PYNATIVE_MODE, jit_config={\"jit_level\": \"O0\"})\n",
+    "ms.device_context.ascend.op_precision.precision_mode(\"force_fp16\")\n",
+    "ms.device_context.ascend.op_precision.matmul_allow_hf32(False)"
    ]
   },
   {
@@ -137,13 +132,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Looking in indexes: https://repo.huaweicloud.com/repository/pypi/simple/\n",
-      "Requirement already satisfied: tqdm in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (4.66.5)\n",
-      "Requirement already satisfied: requests in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (2.32.3)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests) (3.4.0)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests) (3.10)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests) (2.2.3)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests) (2024.8.30)\n"
+      "Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple/\n",
+      "Requirement already satisfied: tqdm in /usr/local/miniconda3/envs/ms/lib/python3.10/site-packages (4.67.1)\n",
+      "Requirement already satisfied: requests in /usr/local/miniconda3/envs/ms/lib/python3.10/site-packages (2.32.4)\n",
+      "Requirement already satisfied: charset_normalizer<4,>=2 in /usr/local/miniconda3/envs/ms/lib/python3.10/site-packages (from requests) (3.4.2)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /usr/local/miniconda3/envs/ms/lib/python3.10/site-packages (from requests) (3.10)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/miniconda3/envs/ms/lib/python3.10/site-packages (from requests) (2.5.0)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/miniconda3/envs/ms/lib/python3.10/site-packages (from requests) (2025.8.3)\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
+      "\u001b[0m"
      ]
     }
    ],
@@ -162,43 +159,25 @@
    },
    "outputs": [],
    "source": [
-    "import os\n",
-    "import shutil\n",
-    "import requests\n",
-    "import tempfile\n",
-    "from tqdm import tqdm\n",
-    "from typing import IO\n",
-    "# from pathlib import Path\n",
+    "cache_dir = os.path.join(os.getcwd(), \"mindspore_examples\")\n",
+    "os.makedirs(cache_dir, exist_ok=True)\n",
     "\n",
-    "# 指定保存路径\n",
-    "cache_dir = os.getcwd() + '/mindspore_examples'\n",
-    "\n",
-    "def http_get(url: str, temp_file: IO):\n",
-    "    \"\"\"使用requests库下载数据，并使用tqdm库进行流程可视化\"\"\"\n",
-    "    req = requests.get(url, stream=True)\n",
-    "    content_length = req.headers.get('Content-Length')\n",
-    "    total = int(content_length) if content_length is not None else None\n",
-    "    progress = tqdm(unit='B', total=total)\n",
-    "    for chunk in req.iter_content(chunk_size=1024):\n",
-    "        if chunk:\n",
-    "            progress.update(len(chunk))\n",
-    "            temp_file.write(chunk)\n",
-    "    progress.close()\n",
+    "def _http_get(url: str, temp_file: IO):\n",
+    "    r = requests.get(url, stream=True, timeout=60)\n",
+    "    total = int(r.headers.get(\"Content-Length\") or 0)\n",
+    "    bar = tqdm(total=total, unit=\"B\", desc=\"file_sizes\")\n",
+    "    for ch in r.iter_content(1024 * 256):\n",
+    "        if ch:\n",
+    "            temp_file.write(ch); bar.update(len(ch))\n",
+    "    bar.close()\n",
     "\n",
     "def downloads(file_name: str, url: str):\n",
-    "    \"\"\"下载数据并存为指定名称\"\"\"\n",
-    "    if not os.path.exists(cache_dir):\n",
-    "        os.makedirs(cache_dir)\n",
-    "    cache_path = os.path.join(cache_dir, file_name)\n",
-    "    cache_exist = os.path.exists(cache_path)\n",
-    "    if not cache_exist:\n",
-    "        with tempfile.NamedTemporaryFile() as temp_file:\n",
-    "            http_get(url, temp_file)\n",
-    "            temp_file.flush()\n",
-    "            temp_file.seek(0)\n",
-    "            with open(cache_path, 'wb') as cache_file:\n",
-    "                shutil.copyfileobj(temp_file, cache_file)\n",
-    "    return cache_path"
+    "    dst = os.path.join(cache_dir, file_name)\n",
+    "    if not os.path.exists(dst):\n",
+    "        with tempfile.NamedTemporaryFile() as t:\n",
+    "            _http_get(url, t); t.flush(); t.seek(0)\n",
+    "            with open(dst, \"wb\") as f: shutil.copyfileobj(t, f)\n",
+    "    return dst"
    ]
   },
   {
@@ -231,30 +210,23 @@
    },
    "outputs": [],
    "source": [
-    "import zipfile\n",
-    "import numpy as np\n",
-    "import mindspore.dataset as ds\n",
+    "def load_glove(glove_zip_path: str):\n",
+    "    glove_100d = os.path.join(cache_dir, \"glove.6B.100d.txt\")\n",
+    "    if not os.path.exists(glove_100d):\n",
+    "        with zipfile.ZipFile(glove_zip_path) as zf: zf.extractall(cache_dir)\n",
     "\n",
-    "def load_glove(glove_path):\n",
-    "    glove_100d_path = os.path.join(cache_dir, 'glove.6B.100d.txt')\n",
-    "    if not os.path.exists(glove_100d_path):\n",
-    "        glove_zip = zipfile.ZipFile(glove_path)\n",
-    "        glove_zip.extractall(cache_dir)\n",
+    "    embs, toks = [], []\n",
+    "    with open(glove_100d, encoding=\"utf-8\") as gf:\n",
+    "        for line in gf:\n",
+    "            w, vec = line.split(maxsplit=1)\n",
+    "            toks.append(w)\n",
+    "            embs.append(np.fromstring(vec, dtype=np.float32, sep=\" \"))\n",
+    "    embs.append(np.random.rand(100).astype(np.float32))  # <unk>\n",
+    "    embs.append(np.zeros((100,), np.float32))            # <pad>\n",
     "\n",
-    "    embeddings = []\n",
-    "    tokens = []\n",
-    "    with open(glove_100d_path, encoding='utf-8') as gf:\n",
-    "        for glove in gf:\n",
-    "            word, embedding = glove.split(maxsplit=1)\n",
-    "            tokens.append(word)\n",
-    "            embeddings.append(np.fromstring(embedding, dtype=np.float32, sep=' '))\n",
-    "    # 添加 <unk>, <pad> 两个特殊占位符对应的embedding\n",
-    "    embeddings.append(np.random.rand(100))\n",
-    "    embeddings.append(np.zeros((100,), np.float32))\n",
-    "\n",
-    "    vocab = ds.text.Vocab.from_list(tokens, special_tokens=[\"<unk>\", \"<pad>\"], special_first=False)\n",
-    "    embeddings = np.array(embeddings).astype(np.float32)\n",
-    "    return vocab, embeddings"
+    "    vocab = ds.text.Vocab.from_list(toks, special_tokens=[\"<unk>\", \"<pad>\"], special_first=False)\n",
+    "    embs = np.asarray(embs, np.float32).astype(np.float16)  # 直接转 FP16\n",
+    "    return vocab, embs"
    ]
   },
   {
@@ -269,19 +241,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "34ca0aee-7deb-45ea-8231-2be5f9c2e632",
    "metadata": {
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 862182613/862182613 [00:21<00:00, 39396514.94B/s]\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
@@ -294,7 +259,8 @@
     }
    ],
    "source": [
-    "glove_path = downloads('glove.6B.zip', 'https://mindspore-website.obs.myhuaweicloud.com/notebook/datasets/glove.6B.zip')\n",
+    "glove_path = downloads(\"glove.6B.zip\",\n",
+    "    \"https://mindspore-website.obs.myhuaweicloud.com/notebook/datasets/glove.6B.zip\")\n",
     "vocab, embeddings = load_glove(glove_path)\n",
     "len(vocab.vocab())"
    ]
@@ -319,23 +285,23 @@
      "data": {
       "text/plain": [
        "(0,\n",
-       " array([-0.038194, -0.24487 ,  0.72812 , -0.39961 ,  0.083172,  0.043953,\n",
-       "        -0.39141 ,  0.3344  , -0.57545 ,  0.087459,  0.28787 , -0.06731 ,\n",
-       "         0.30906 , -0.26384 , -0.13231 , -0.20757 ,  0.33395 , -0.33848 ,\n",
-       "        -0.31743 , -0.48336 ,  0.1464  , -0.37304 ,  0.34577 ,  0.052041,\n",
-       "         0.44946 , -0.46971 ,  0.02628 , -0.54155 , -0.15518 , -0.14107 ,\n",
-       "        -0.039722,  0.28277 ,  0.14393 ,  0.23464 , -0.31021 ,  0.086173,\n",
-       "         0.20397 ,  0.52624 ,  0.17164 , -0.082378, -0.71787 , -0.41531 ,\n",
-       "         0.20335 , -0.12763 ,  0.41367 ,  0.55187 ,  0.57908 , -0.33477 ,\n",
-       "        -0.36559 , -0.54857 , -0.062892,  0.26584 ,  0.30205 ,  0.99775 ,\n",
-       "        -0.80481 , -3.0243  ,  0.01254 , -0.36942 ,  2.2167  ,  0.72201 ,\n",
-       "        -0.24978 ,  0.92136 ,  0.034514,  0.46745 ,  1.1079  , -0.19358 ,\n",
-       "        -0.074575,  0.23353 , -0.052062, -0.22044 ,  0.057162, -0.15806 ,\n",
-       "        -0.30798 , -0.41625 ,  0.37972 ,  0.15006 , -0.53212 , -0.2055  ,\n",
-       "        -1.2526  ,  0.071624,  0.70565 ,  0.49744 , -0.42063 ,  0.26148 ,\n",
-       "        -1.538   , -0.30223 , -0.073438, -0.28312 ,  0.37104 , -0.25217 ,\n",
-       "         0.016215, -0.017099, -0.38984 ,  0.87424 , -0.72569 , -0.51058 ,\n",
-       "        -0.52028 , -0.1459  ,  0.8278  ,  0.27062 ], dtype=float32))"
+       " array([-0.0382 , -0.2449 ,  0.728  , -0.3997 ,  0.0832 ,  0.04395,\n",
+       "        -0.3914 ,  0.3345 , -0.5757 ,  0.08746,  0.2878 , -0.0673 ,\n",
+       "         0.309  , -0.264  , -0.1323 , -0.2075 ,  0.334  , -0.3384 ,\n",
+       "        -0.3174 , -0.4834 ,  0.1464 , -0.373  ,  0.3457 ,  0.05203,\n",
+       "         0.4495 , -0.4697 ,  0.02628, -0.5415 , -0.1552 , -0.1411 ,\n",
+       "        -0.03973,  0.2827 ,  0.1439 ,  0.2346 , -0.3103 ,  0.0862 ,\n",
+       "         0.204  ,  0.5264 ,  0.1716 , -0.0824 , -0.718  , -0.4153 ,\n",
+       "         0.2034 , -0.1277 ,  0.4136 ,  0.552  ,  0.579  , -0.3347 ,\n",
+       "        -0.3655 , -0.5483 , -0.06287,  0.2659 ,  0.302  ,  0.9976 ,\n",
+       "        -0.8047 , -3.023  ,  0.01254, -0.3694 ,  2.217  ,  0.722  ,\n",
+       "        -0.2498 ,  0.9214 ,  0.03452,  0.4675 ,  1.107  , -0.1936 ,\n",
+       "        -0.0746 ,  0.2335 , -0.05206, -0.2205 ,  0.05716, -0.1581 ,\n",
+       "        -0.3079 , -0.4163 ,  0.3796 ,  0.15   , -0.532  , -0.2054 ,\n",
+       "        -1.253  ,  0.0716 ,  0.7056 ,  0.4976 , -0.4207 ,  0.2615 ,\n",
+       "        -1.538  , -0.3022 , -0.0734 , -0.2832 ,  0.371  , -0.2522 ,\n",
+       "         0.01622, -0.0171 , -0.39   ,  0.874  , -0.7256 , -0.5107 ,\n",
+       "        -0.5205 , -0.1459 ,  0.8276 ,  0.2705 ], dtype=float16))"
       ]
      },
      "execution_count": 6,
@@ -420,33 +386,63 @@
    },
    "outputs": [],
    "source": [
-    "import math\n",
-    "import mindspore as ms\n",
-    "import mindspore.nn as nn\n",
-    "import mindspore.ops as ops\n",
-    "from mindspore.common.initializer import Uniform, HeUniform\n",
-    "\n",
-    "class RNN(nn.Cell):\n",
-    "    def __init__(self, embeddings, hidden_dim, output_dim, n_layers,\n",
-    "                 bidirectional, pad_idx):\n",
+    "class RNN(ms.nn.Cell):\n",
+    "    def __init__(self, emb_table: np.ndarray, hidden: int, num_layers: int, pad_idx: int):\n",
     "        super().__init__()\n",
-    "        vocab_size, embedding_dim = embeddings.shape\n",
-    "        self.embedding = nn.Embedding(vocab_size, embedding_dim, embedding_table=ms.Tensor(embeddings), padding_idx=pad_idx)\n",
-    "        self.rnn = nn.LSTM(embedding_dim,\n",
-    "                           hidden_dim,\n",
-    "                           num_layers=n_layers,\n",
-    "                           bidirectional=bidirectional,\n",
-    "                           batch_first=True)\n",
-    "        weight_init = HeUniform(math.sqrt(5))\n",
-    "        bias_init = Uniform(1 / math.sqrt(hidden_dim * 2))\n",
-    "        self.fc = nn.Dense(hidden_dim * 2, output_dim, weight_init=weight_init, bias_init=bias_init)\n",
+    "        vocab_size, emb_dim = emb_table.shape\n",
+    "        self.embedding = mnn.Embedding(\n",
+    "            num_embeddings=vocab_size,\n",
+    "            embedding_dim=emb_dim,\n",
+    "            padding_idx=pad_idx,\n",
+    "            _weight=ms.Tensor(emb_table, ms.float16),\n",
+    "            _freeze=False, dtype=ms.float16\n",
+    "        )\n",
     "\n",
-    "    def construct(self, inputs):\n",
-    "        embedded = self.embedding(inputs)\n",
-    "        _, (hidden, _) = self.rnn(embedded)\n",
-    "        hidden = ops.concat((hidden[-2, :, :], hidden[-1, :, :]), axis=1)\n",
-    "        output = self.fc(hidden)\n",
-    "        return output"
+    "        self.hidden = hidden\n",
+    "        self.num_layers = num_layers\n",
+    "        in_sizes = [emb_dim] + [2*hidden] * (num_layers - 1)\n",
+    "\n",
+    "        self.fwd_cells = ms.nn.CellList([\n",
+    "            ms.nn.LSTMCell(input_size=in_sizes[i], hidden_size=hidden, dtype=ms.float16)\n",
+    "            for i in range(num_layers)\n",
+    "        ])\n",
+    "        self.bwd_cells = ms.nn.CellList([\n",
+    "            ms.nn.LSTMCell(input_size=in_sizes[i], hidden_size=hidden, dtype=ms.float16)\n",
+    "            for i in range(num_layers)\n",
+    "        ])\n",
+    "\n",
+    "        self.fc = mnn.Linear(in_features=2*hidden, out_features=1, bias=True, dtype=ms.float16)\n",
+    "\n",
+    "    def _run_one_layer_dir(self, x_seq: ms.Tensor, cell: ms.nn.Cell, reverse: bool):\n",
+    "        B, T, _ = x_seq.shape\n",
+    "        outs = [None] * T\n",
+    "        h = ms.ops.zeros((B, self.hidden), ms.float16)\n",
+    "        c = ms.ops.zeros((B, self.hidden), ms.float16)\n",
+    "        idx = range(T-1, -1, -1) if reverse else range(T)\n",
+    "        for t in idx:\n",
+    "            xt = x_seq[:, t, :]\n",
+    "            h, c = cell(xt, (h, c))\n",
+    "            outs[t] = h \n",
+    "        y_seq = mint.stack(outs, dim=1)   # (B,T,H)\n",
+    "        h_last = outs[0] if reverse else outs[T-1]\n",
+    "        return y_seq, h_last\n",
+    "\n",
+    "    def construct(self, ids: ms.Tensor):\n",
+    "        # ids: (B,T) int32\n",
+    "        seq_in = self.embedding(ids).astype(ms.float16)  # (B,T,E)\n",
+    "        h_f_last = h_b_last = None\n",
+    "\n",
+    "        for l in range(self.num_layers):\n",
+    "            y_f, h_f = self._run_one_layer_dir(seq_in, self.fwd_cells[l], reverse=False)  # (B,T,H)\n",
+    "            y_b, h_b = self._run_one_layer_dir(seq_in, self.bwd_cells[l], reverse=True)   # (B,T,H)\n",
+    "            if l < self.num_layers - 1:\n",
+    "                seq_in = mint.cat((y_f, y_b), dim=2)\n",
+    "            else:\n",
+    "                h_f_last, h_b_last = h_f, h_b\n",
+    "\n",
+    "        feat = mint.cat((h_f_last, h_b_last), dim=1)  # (B,2H)\n",
+    "        logits = self.fc(feat)                        # (B,1)  FP16\n",
+    "        return logits"
    ]
   },
   {
@@ -456,15 +452,45 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[WARNING] ME(202451:255086384599072,MainProcess):2025-08-09-04:28:46.653.000 [mindspore/nn/layer/rnn_cells.py:68] LSTMCell has been changed from 'single LSTM layer' to 'single LSTM cell', if you still need use single LSTM layer, please use `nn.LSTM` instead.\n",
+      "[WARNING] ME(202451:255086384599072,MainProcess):2025-08-09-04:28:46.716.000 [mindspore/nn/layer/rnn_cells.py:68] LSTMCell has been changed from 'single LSTM layer' to 'single LSTM cell', if you still need use single LSTM layer, please use `nn.LSTM` instead.\n",
+      "[WARNING] ME(202451:255086384599072,MainProcess):2025-08-09-04:28:46.841.000 [mindspore/nn/layer/rnn_cells.py:68] LSTMCell has been changed from 'single LSTM layer' to 'single LSTM cell', if you still need use single LSTM layer, please use `nn.LSTM` instead.\n",
+      "[WARNING] ME(202451:255086384599072,MainProcess):2025-08-09-04:28:46.903.000 [mindspore/nn/layer/rnn_cells.py:68] LSTMCell has been changed from 'single LSTM layer' to 'single LSTM cell', if you still need use single LSTM layer, please use `nn.LSTM` instead.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "RNN(\n",
+       "  (embedding): EmbeddingExt(num_embeddings=400002, embedding_dim=100, padding_idx=400001, max_norm=None, norm_type=2.0, scale_grad_by_freq=False, dtype=Float16)\n",
+       "  (fwd_cells): CellList(\n",
+       "    (0): LSTMCell()\n",
+       "    (1): LSTMCell()\n",
+       "  )\n",
+       "  (bwd_cells): CellList(\n",
+       "    (0): LSTMCell()\n",
+       "    (1): LSTMCell()\n",
+       "  )\n",
+       "  (fc): Linear(input_features=512, output_features=1, has_bias=True)\n",
+       ")"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "hidden_size = 256\n",
-    "output_size = 1\n",
-    "num_layers = 2\n",
-    "bidirectional = True\n",
-    "pad_idx = vocab.tokens_to_ids('<pad>')\n",
-    "\n",
-    "model = RNN(embeddings, hidden_size, output_size, num_layers, bidirectional, pad_idx)"
+    "num_layers  = 2\n",
+    "pad_idx     = vocab.tokens_to_ids(\"<pad>\")\n",
+    "model = RNN(embeddings, hidden=hidden_size, num_layers=num_layers, pad_idx=pad_idx)\n",
+    "model.set_train(False)"
    ]
   },
   {
@@ -488,15 +514,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Looking in indexes: https://repo.huaweicloud.com/repository/pypi/simple/\n",
-      "Requirement already satisfied: download in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (0.3.5)\n",
-      "Requirement already satisfied: tqdm in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from download) (4.66.5)\n",
-      "Requirement already satisfied: six in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from download) (1.16.0)\n",
-      "Requirement already satisfied: requests in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from download) (2.32.3)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests->download) (3.4.0)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests->download) (3.10)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests->download) (2.2.3)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /home/mindspore/miniconda/envs/jupyter/lib/python3.9/site-packages (from requests->download) (2024.8.30)\n"
+      "Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple/\n",
+      "Requirement already satisfied: download in /usr/local/miniconda3/envs/ms/lib/python3.10/site-packages (0.3.5)\n",
+      "Requirement already satisfied: tqdm in /usr/local/miniconda3/envs/ms/lib/python3.10/site-packages (from download) (4.67.1)\n",
+      "Requirement already satisfied: six in /usr/local/miniconda3/envs/ms/lib/python3.10/site-packages (from download) (1.17.0)\n",
+      "Requirement already satisfied: requests in /usr/local/miniconda3/envs/ms/lib/python3.10/site-packages (from download) (2.32.4)\n",
+      "Requirement already satisfied: charset_normalizer<4,>=2 in /usr/local/miniconda3/envs/ms/lib/python3.10/site-packages (from requests->download) (3.4.2)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /usr/local/miniconda3/envs/ms/lib/python3.10/site-packages (from requests->download) (3.10)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/miniconda3/envs/ms/lib/python3.10/site-packages (from requests->download) (2.5.0)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/miniconda3/envs/ms/lib/python3.10/site-packages (from requests->download) (2025.8.3)\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
+      "\u001b[0m"
      ]
     }
    ],
@@ -508,21 +536,90 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "d477ec12-04ff-488b-8d31-ae82e5e9be2f",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading data from https://cdn.modelers.cn/lfs/b1/d6/c2ab538684d08d744bd6b262bdc243e00ad2c0af819e429c9e7574370e3a?response-content-disposition=attachment%3B+filename%3D%22sentiment-analysis.ckpt%22&AWSAccessKeyId=HAZQA0Q6AQL2GHX4TKTL&Expires=1754771330&Signature=MCyh%2BgVbrkKSs8BTnLnBhz%2F4fVo%3D (161.4 MB)\n",
+      "\n",
+      "file_sizes: 100%|████████████████████████████| 169M/169M [00:02<00:00, 76.6MB/s]\n",
+      "Successfully downloaded file to ./sentiment-analysis.ckpt\n",
+      "OK: 已把 nn.LSTM 的 ckpt 映射加载到 LSTMCell BiLSTM（直接 set_data，避免名字前缀问题）。\n"
+     ]
+    }
+   ],
    "source": [
     "# download ckpt\n",
     "from download import download\n",
     "rnn_url = \"https://modelers.cn/coderepo/web/v1/file/MindSpore-Lab/cluoud_obs/main/media/examples/mindspore-courses/orange-pi-online-infer/07-RNN/sentiment-analysis.ckpt\"\n",
     "path = \"./sentiment-analysis.ckpt\"\n",
     "ckpt_path = download(rnn_url, path, replace=True)\n",
+    "def _to_np(x): return x.asnumpy() if hasattr(x, \"asnumpy\") else np.asarray(x)\n",
     "\n",
-    "param_dict = ms.load_checkpoint(ckpt_path)\n",
-    "ms.load_param_into_net(model, param_dict)"
+    "def load_lstm_ckpt_into_cell_bilstm(model: RNN, ckpt_path: str, strict_shape=True):\n",
+    "    \"\"\"\n",
+    "    将 nn.LSTM(bidir=True, num_layers=2) 的 ckpt 映射到我们的 LSTMCell BiLSTM。\n",
+    "    直接使用 set_data 写入各个参数，避免名字前缀带来的 KeyError。\n",
+    "    \"\"\"\n",
+    "    st = ms.load_checkpoint(ckpt_path)\n",
+    "    keys = set(st.keys())\n",
+    "\n",
+    "    def _as_np(x):  \n",
+    "        return x.asnumpy() if hasattr(x, \"asnumpy\") else np.asarray(x)\n",
+    "\n",
+    "    emb_key = \"embedding.embedding_table\" if \"embedding.embedding_table\" in keys else \\\n",
+    "              (\"embedding.weight\" if \"embedding.weight\" in keys else None)\n",
+    "    if emb_key is not None:\n",
+    "        np_val = _as_np(st[emb_key])\n",
+    "        tgt = model.embedding.weight \n",
+    "        if strict_shape:\n",
+    "            assert tuple(tgt.shape) == tuple(np_val.shape), f\"embedding shape {tgt.shape} vs {np_val.shape}\"\n",
+    "        tgt.set_data(ms.Tensor(np_val.astype(ms.dtype_to_nptype(tgt.dtype)), tgt.dtype))\n",
+    "\n",
+    "    for l in range(model.num_layers):\n",
+    "        for is_rev, cells in [(False, model.fwd_cells), (True, model.bwd_cells)]:\n",
+    "            suf = \"_reverse\" if is_rev else \"\"\n",
+    "            cell = cells[l]\n",
+    "            need = {\n",
+    "                \"wih\": f\"rnn.weight_ih_l{l}{suf}\",\n",
+    "                \"whh\": f\"rnn.weight_hh_l{l}{suf}\",\n",
+    "                \"bih\": f\"rnn.bias_ih_l{l}{suf}\",\n",
+    "                \"bhh\": f\"rnn.bias_hh_l{l}{suf}\",\n",
+    "            }\n",
+    "            for k in need.values():\n",
+    "                if k not in keys:\n",
+    "                    raise KeyError(f\"ckpt 缺少键: {k}\")\n",
+    "\n",
+    "            wih = _as_np(st[need[\"wih\"]]); whh = _as_np(st[need[\"whh\"]])\n",
+    "            bih = _as_np(st[need[\"bih\"]]); bhh = _as_np(st[need[\"bhh\"]])\n",
+    "\n",
+    "            if strict_shape:\n",
+    "                assert tuple(cell.weight_ih.shape) == tuple(wih.shape), f\"L{l}{suf} weight_ih {cell.weight_ih.shape} vs {wih.shape}\"\n",
+    "                assert tuple(cell.weight_hh.shape) == tuple(whh.shape), f\"L{l}{suf} weight_hh {cell.weight_hh.shape} vs {whh.shape}\"\n",
+    "                assert tuple(cell.bias_ih.shape)   == tuple(bih.shape), f\"L{l}{suf} bias_ih   {cell.bias_ih.shape} vs {bih.shape}\"\n",
+    "                assert tuple(cell.bias_hh.shape)   == tuple(bhh.shape), f\"L{l}{suf} bias_hh   {cell.bias_hh.shape} vs {bhh.shape}\"\n",
+    "\n",
+    "            cell.weight_ih.set_data(ms.Tensor(wih.astype(ms.dtype_to_nptype(cell.weight_ih.dtype)), cell.weight_ih.dtype))\n",
+    "            cell.weight_hh.set_data(ms.Tensor(whh.astype(ms.dtype_to_nptype(cell.weight_hh.dtype)), cell.weight_hh.dtype))\n",
+    "            cell.bias_ih.set_data(ms.Tensor(bih.astype(ms.dtype_to_nptype(cell.bias_ih.dtype)),   cell.bias_ih.dtype))\n",
+    "            cell.bias_hh.set_data(ms.Tensor(bhh.astype(ms.dtype_to_nptype(cell.bias_hh.dtype)),   cell.bias_hh.dtype))\n",
+    "\n",
+    "    for name in (\"fc.weight\", \"fc.bias\"):\n",
+    "        if name in keys and hasattr(model.fc, name.split(\".\")[1]):\n",
+    "            np_val = _as_np(st[name])\n",
+    "            tgt = getattr(model.fc, name.split(\".\")[1])  # weight / bias\n",
+    "            if strict_shape:\n",
+    "                assert tuple(tgt.shape) == tuple(np_val.shape), f\"{name} {tgt.shape} vs {np_val.shape}\"\n",
+    "            tgt.set_data(ms.Tensor(np_val.astype(ms.dtype_to_nptype(tgt.dtype)), tgt.dtype))\n",
+    "\n",
+    "    print(\"OK: 已把 nn.LSTM 的 ckpt 映射加载到 LSTMCell BiLSTM（直接 set_data，避免名字前缀问题）。\")\n",
+    "load_lstm_ckpt_into_cell_bilstm(model, ckpt_path, strict_shape=True)"
    ]
   },
   {
@@ -552,19 +649,16 @@
    },
    "outputs": [],
    "source": [
-    "score_map = {\n",
-    "    1: \"Positive\",\n",
-    "    0: \"Negative\"\n",
-    "}\n",
-    "\n",
-    "def predict_sentiment(model, vocab, sentence):\n",
-    "    model.set_train(False)\n",
-    "    tokenized = sentence.lower().split()\n",
-    "    indexed = vocab.tokens_to_ids(tokenized)\n",
-    "    tensor = ms.Tensor(indexed, ms.int32)\n",
-    "    tensor = tensor.expand_dims(0)\n",
-    "    prediction = model(tensor)\n",
-    "    return score_map[int(np.round(ops.sigmoid(prediction).asnumpy()))]"
+    "score_map = {1: \"Positive\", 0: \"Negative\"}\n",
+    "def predict_sentiment(net: ms.nn.Cell, vocab: ds.text.Vocab, sentence: str):\n",
+    "    tokens = sentence.lower().split()\n",
+    "    ids = vocab.tokens_to_ids(tokens)\n",
+    "    if isinstance(ids, int):\n",
+    "        ids = [ids]\n",
+    "    x = ms.Tensor(np.array(ids, dtype=np.int32)[None, :], ms.int32)\n",
+    "    logits = net(x)                                   # (1,1) FP16\n",
+    "    prob = F.sigmoid(logits.astype(ms.float32)).asnumpy().item()\n",
+    "    return score_map[int(prob >= 0.5)], prob"
    ]
   },
   {
@@ -584,60 +678,9 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.372.155 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.372.231 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.372.420 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.372.443 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.373.577 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.373.600 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.373.682 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.373.702 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.373.758 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.373.778 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.373.879 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.373.899 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.373.952 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.373.971 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.374.035 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.374.056 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.374.119 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.374.139 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.374.246 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.374.265 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.374.326 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.374.346 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.375.740 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.375.761 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.375.808 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.375.827 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.375.881 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.375.900 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.375.943 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.375.962 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.376.020 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.376.040 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.376.081 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.376.100 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.376.155 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.376.174 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n",
-      "[ERROR] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.376.217 [mindspore/core/utils/file_utils.cc:253] GetRealPath] Get realpath failed, path[/tmp/ipykernel_11519/1184826325.py]\n",
-      "[WARNING] CORE(11519,ffff87a57b80,python):2025-02-22-07:39:11.376.236 [mindspore/core/utils/info.cc:120] ToString] The file '/tmp/ipykernel_11519/1184826325.py' may not exists.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\\\r"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "'Negative'"
+       "('Negative', 0.06075190007686615)"
       ]
      },
      "execution_count": 12,
@@ -660,7 +703,7 @@
     {
      "data": {
       "text/plain": [
-       "'Positive'"
+       "('Positive', 0.7727022171020508)"
       ]
      },
      "execution_count": 13,
@@ -689,7 +732,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.10.18"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
任务编号：ICJ93I
任务链接：[【开源实习】香橙派github仓中的在线推理案例07-RNN基于PyNative模式改写成以mint接口实现](https://gitee.com/mindspore/community/issues/ICJ93I)
环境：Python 3.10 + MindSpore 2.6.0 + CANN 8.1.RC1 + OrangePi AiPro 8G 8T (ubuntu-22.04)
推理结果：
<img width="746" height="418" alt="image" src="https://github.com/user-attachments/assets/0b0ddd54-9369-4e0d-84d8-81d31a540fcc" />
